### PR TITLE
V0.1.29 dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "fm-tui"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fm-tui"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Quentin Konieczko <qu3nt1n@gmail.com>"]
 edition = "2021"
 license-file = "LICENSE.txt"

--- a/build.rs
+++ b/build.rs
@@ -30,8 +30,12 @@ fn main() {
 fn update_breaking_config() {
     let config = tilde("~/.config/fm/config.yaml");
     let config: &str = config.borrow();
-    let content = std::fs::read_to_string(config)
-        .expect("config file should be readable")
+
+    let Ok(config_file) = std::fs::read_to_string(config) else {
+        // Config file doesn't exist, nothing to update.
+        return;
+    };
+    let content = config_file
         .lines()
         .map(String::from)
         .filter(|line| !line.contains("Jump"))

--- a/build.rs
+++ b/build.rs
@@ -20,29 +20,6 @@ fn main() {
         Ok(_) => (),
         Err(e) => eprintln!("{e:?}"),
     }
-
-    update_breaking_config()
-}
-
-/// Remove old binds from user config file.
-///
-/// Remove all binds to `Jump` and `Mocp...` variants since they were removed from fm.
-fn update_breaking_config() {
-    let config = tilde("~/.config/fm/config.yaml");
-    let config: &str = config.borrow();
-
-    let Ok(config_file) = std::fs::read_to_string(config) else {
-        // Config file doesn't exist, nothing to update.
-        return;
-    };
-    let content = config_file
-        .lines()
-        .map(String::from)
-        .filter(|line| !line.contains("Jump"))
-        .filter(|line| !line.contains("Mocp"))
-        .collect::<Vec<String>>()
-        .join("\n");
-    std::fs::write(config, content).expect("config should be writabe");
 }
 
 fn home_dir() -> Option<std::path::PathBuf> {

--- a/config_files/fm/config.yaml
+++ b/config_files/fm/config.yaml
@@ -38,7 +38,7 @@ colors:
   fifo: blue
   socket: cyan
   symlink: magenta
-  broken: light_magenta
+  broken: blue
 
 # Colors for menus, headers, footers etc.
 # The same values are accepted.

--- a/config_files/fm/config.yaml
+++ b/config_files/fm/config.yaml
@@ -7,21 +7,6 @@ terminal: st
 
 # configurable colors
 
-# Define a palette for the "normal" files.
-# File will be colored randomly from their extensions.
-# List of allowed ANSI colors:
-#   white,        black,        red,       green,       blue,       yellow,       cyan,       magenta 
-#   light_white,  light_black,  light_red, light_green, light_blue, light_yellow, light_cyan, light_magenta 
-# Allowed Format for rgb color :
-#   - `rgb(r, g, b)` where r, g and b are integers between 0 and 255 included.
-#   - `#rrggbb` aka hex colors, where rr, gg and bb are hexadecimals
-# palette:
-#   start: "rgb(255, 110, 128)"
-#   stop: "rgb(123, 100, 255)"
-palette:
-  start: green
-  stop: blue
-
 # Colors for "non normal" files. The list is below.
 # you can define an ANSI color or an rgb color for any kind of file except "normal" files.
 # colors for normal files are calculated on the fly from the "palette" values provided above.
@@ -32,30 +17,44 @@ palette:
 #   - `rgb(r, g, b)` where r, g and b are integers between 0 and 255 included.
 #   - `#rrggbb` aka hex colors, where rr, gg and bb are hexadecimals
 colors:
-  directory: red
-  block: yellow
-  char: green
-  fifo: blue
-  socket: cyan
-  symlink: magenta
-  broken: blue
+  # Gradient from start to stop for normal files.
+  # the files are colored randomly according to their extension
+  # ANSI colors won't be linked to their configured values but to the default ANSI values.
+  normal_start:     rgb(187, 102, 255)
+  normal_stop:      rgb(255, 102, 187)
 
-# Colors for menus, headers, footers etc.
-# The same values are accepted.
-menu_colors:
+  # color for different filekinds
+  # here you can use ANSI values
+  # colors for folders / directory
+  directory:        rgb(45, 250, 209)
+  # block device (hard drives...)
+  block:            rgb(231, 100, 100)
+  # char devices (ttys, /dev/urandom etc.)
+  char:             rgb(230, 189, 87)
+  # fifos
+  fifo:             rgb(180, 255, 255)
+  # opened sockets
+  socket:           rgb(231, 100, 100)
+  # valid symlinks
+  symlink:          rgb(59, 204, 255)
+  # broken symlinks
+  broken:           rgb(140, 140, 140)
+
+  # Colors for menus, headers, footers etc.
+  # The same values are accepted.
   # first color
-  first: rgb(45, 250, 209)
+  header_first:     rgb(45, 250, 209)
   # second color
-  second: rgb(230, 189, 87)
+  header_second:    rgb(230, 189, 87)
   # selected tab border
-  selected_border: rgb(45, 250, 209)
+  selected_border:  rgb(45, 250, 209)
   # non selected tab border
-  inert_border: rgb(120, 120, 120)
-  # palette of 4 elements, used in menus (second window) and header
-  palette_1: rgb(45, 250, 209)
-  palette_2: rgb(230, 189, 87)
-  palette_3: rgb(230, 167, 255)
-  palette_4: rgb(59, 204, 255)
+  inert_border:     rgb(120, 120, 120)
+  # palette of 4 elements, used in menus (second window)
+  palette_1:        rgb(45, 250, 209)
+  palette_2:        rgb(230, 189, 87)
+  palette_3:        rgb(230, 167, 255)
+  palette_4:        rgb(59, 204, 255)
 
 # keybindings
 # 

--- a/config_files/fm/config.yaml
+++ b/config_files/fm/config.yaml
@@ -9,11 +9,12 @@ terminal: st
 
 # Define a palette for the "normal" files.
 # File will be colored randomly from their extensions.
-# Accepted values are "red", "green", "blue" or a rgb color
+# List of allowed ANSI colors:
+#   white,        black,        red,       green,       blue,       yellow,       cyan,       magenta 
+#   light_white,  light_black,  light_red, light_green, light_blue, light_yellow, light_cyan, light_magenta 
 # Allowed Format for rgb color :
 #   - `rgb(r, g, b)` where r, g and b are integers between 0 and 255 included.
 #   - `#rrggbb` aka hex colors, where rr, gg and bb are hexadecimals
-# Unfortunatelly, not all ansi color names are accepted.
 # palette:
 #   start: "rgb(255, 110, 128)"
 #   stop: "rgb(123, 100, 255)"
@@ -22,15 +23,15 @@ palette:
   stop: blue
 
 # Colors for "non normal" files. The list is below.
+# you can define an ANSI color or an rgb color for any kind of file except "normal" files.
+# colors for normal files are calculated on the fly from the "palette" values provided above.
+# List of allowed ANSI colors:
+#   white,        black,        red,       green,       blue,       yellow,       cyan,       magenta 
+#   light_white,  light_black,  light_red, light_green, light_blue, light_yellow, light_cyan, light_magenta 
+# Allowed Format for rgb color :
+#   - `rgb(r, g, b)` where r, g and b are integers between 0 and 255 included.
+#   - `#rrggbb` aka hex colors, where rr, gg and bb are hexadecimals
 colors:
-  # you can define an ANSI color or an rgb color for any kind of file except "normal" files.
-  # colors for normal files are calculated on the fly.
-  # List of allowed colors:
-  #   white,        black,        red,       green,       blue,       yellow,       cyan,       magenta 
-  #   light_white,  light_black,  light_red, light_green, light_blue, light_yellow, light_cyan, light_magenta 
-  # Allowed Format for rgb color :
-  #   - `rgb(r, g, b)` where r, g and b are integers between 0 and 255 included.
-  #   - `#rrggbb` aka hex colors, where rr, gg and bb are hexadecimals
   directory: red
   block: yellow
   char: green
@@ -40,6 +41,7 @@ colors:
   broken: light_magenta
 
 # Colors for menus, headers, footers etc.
+# The same values are accepted.
 menu_colors:
   # first color
   first: rgb(45, 250, 209)
@@ -148,6 +150,7 @@ keys:
 custom:
   # open the selected file with chrome
   'alt-u': "/usr/bin/google-chrome-stable %s"
+  # drag & drop the selected file to a GUI application
   'shift-d': "/usr/bin/dragon-drop %s"  
 
 # DO NOT EDIT UNLESS YOU WANT TO ADD AN UNKNOWN TERMINAL EMULATOR

--- a/development.md
+++ b/development.md
@@ -1125,7 +1125,9 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview builder
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible
-- [ ] preview symlink to folder as the target
+- [x] preview symlink to folder as the target
+- [ ] preview symlink to files as the target. More difficult, must change PreviewBuilder completely
+- [x] Alt+g should accept pathes to file from input and go there
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1112,7 +1112,8 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 
 - [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
   - [ ] refactor path reducer
-- [ ] Bug: when ".." is selected, header path is wrong. This is a big one...
+- [x] Fix: when ".." is selected, header path is wrong. This is a big one...
+- [ ] when path is root, header is wrong, should just be "/""run" not "/""/run"
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1052,8 +1052,6 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [ ] FIX: alt + g, type, complete, back crash. Can't reproduce
 - [x] FIX: too much thing on menu and last line
 
-## Current dev
-
 ### Version 0.1.28
 
 #### Summary
@@ -1103,6 +1101,16 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] refactor draw tree line
 - [x] Fix: Crash when quiting. "sending on a closed channel". From quit -> refresher::quit
 - [ ] Badges to latest version
+
+## Current dev
+
+### Version 0.1.29
+
+#### Summary
+
+#### Changelog
+
+- [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1115,7 +1115,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] Fix: when ".." is selected, header path is wrong. This is a big one...
 - [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
 - [x] Fix attempt of docs. Don't panic in build if no config file is found. That was dumb
-- [ ] Bug: Tree mode, when path is root, header is wrong
+- [x] Fix: Tree mode, when path is root, header is wrong
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1140,10 +1140,11 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] use a menu to display flagged files
   - [x] display binds
 - [x] refactor context menu "more info" into a struct with explicit methods
+- [x] simplify history a little
+- [ ] simplify color configuration
+  - [x] only one "colors" map in yaml file
+  - [ ] migration of config file : display a warning
 - [ ] google drive should be a display ?
-- [ ] don't use ANSI colors
-  - [ ] config
-  - [ ] src
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1114,6 +1114,16 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - Fix jump mode (Alt+g) to allow paths to file. It will jump there and select the file.
 - Preview valid symlink as their target. Broken symlink aren't previewed at all
 - Fixed a few bugs. See details below.
+- **Breaking changes**: color configuration.
+
+  Only one mapping is used in config.yml. All colors are now regrouped there.
+  Some names have changed :
+
+  - "start" -> "normal_start"
+  - "stop" -> "normal_stop"
+
+  Your old config will still be loaded, but their colors won't be recognized unless you update the config.
+  See the [source](config_file/fm/config.yml) for more infos.
 
 #### Changelog
 
@@ -1141,9 +1151,9 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] display binds
 - [x] refactor context menu "more info" into a struct with explicit methods
 - [x] simplify history a little
-- [ ] simplify color configuration
+- [x] simplify color configuration
   - [x] only one "colors" map in yaml file
-  - [ ] migration of config file : display a warning
+  - [x] migration of config file : detailed in release
 - [ ] google drive should be a display ?
 
 ## TODO

--- a/development.md
+++ b/development.md
@@ -1116,6 +1116,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
 - [x] Fix attempt of docs. Don't panic in build if no config file is found. That was dumb
 - [x] Fix: Tree mode, when path is root, header is wrong
+- [x] Alt+g should accept pathes to file from input and go there
 - [ ] Preview refactor
   - [x] mod for ueberzug
   - [x] builder for ueberzug
@@ -1123,11 +1124,10 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] video slideshow
   - [x] Fix: ueberzug creation may crash the app (poison lock etc.) `Error: Error locking status: poisoned lock: another task failed inside`
   - [x] preview builder
+  - [x] preview symlink to folder as the target
+  - [ ] preview symlink to files as the target. More difficult, must change PreviewBuilder completely
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible
-- [x] preview symlink to folder as the target
-- [ ] preview symlink to files as the target. More difficult, must change PreviewBuilder completely
-- [x] Alt+g should accept pathes to file from input and go there
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1125,6 +1125,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview builder
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible
+- [ ] Focus & mouseover
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1111,9 +1111,10 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 #### Changelog
 
 - [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
-  - [ ] refactor path reducer
+  - [x] refactor path reducer
 - [x] Fix: when ".." is selected, header path is wrong. This is a big one...
-- [ ] when path is root, header is wrong, should just be "/""run" not "/""/run"
+- [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
+- [ ] Bug: Tree mode, when path is root, header is wrong
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1135,7 +1135,6 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview symlink to files as the target. Must change PreviewBuilder completely
   - [x] merge all previews which hold text into a single variant
   - [ ] preview refactor
-    - [ ] enum Preview -> struct Preview {kind: kind, content: window+selectable+draw}
   - [ ] simplify the mess as much as possible
 - [x] flagged should be a menu
   - [x] use a menu to display flagged files

--- a/development.md
+++ b/development.md
@@ -1116,6 +1116,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
 - [x] Fix attempt of docs. Don't panic in build if no config file is found. That was dumb
 - [x] Fix: Tree mode, when path is root, header is wrong
+- [ ] video slideshow
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1126,6 +1126,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview builder
   - [x] preview symlink to folder as the target
   - [x] preview symlink to files as the target. Must change PreviewBuilder completely
+  - [x] merge all previews which hold text into a single variant
   - [ ] preview refactor
     - [ ] enum Preview -> struct Preview {kind: kind, content: window+selectable+draw}
   - [ ] simplify the mess as much as possible

--- a/development.md
+++ b/development.md
@@ -1127,14 +1127,13 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 
 #### Changelog
 
-- [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
-  - [x] refactor path reducer
+- [x] refactor path reducer
 - [x] Fix: when ".." is selected, header path is wrong. This is a big one...
 - [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
 - [x] Fix attempt of docs. Don't panic in build if no config file is found. That was dumb
 - [x] Fix: Tree mode, when path is root, header is wrong
 - [x] Alt+g should accept pathes to file from input and go there
-- [ ] Preview refactor
+- [x] Preview refactor
   - [x] mod for ueberzug
   - [x] builder for ueberzug
   - [x] creator for thumbnail
@@ -1144,8 +1143,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview symlink to folder as the target
   - [x] preview symlink to files as the target. Must change PreviewBuilder completely
   - [x] merge all previews which hold text into a single variant
-  - [ ] preview refactor
-  - [ ] simplify the mess as much as possible
+  - [x] simplify the mess as much as possible
 - [x] flagged should be a menu
   - [x] use a menu to display flagged files
   - [x] display binds
@@ -1154,10 +1152,16 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] simplify color configuration
   - [x] only one "colors" map in yaml file
   - [x] migration of config file : detailed in release
-- [ ] google drive should be a display ?
 
 ## TODO
 
+- [ ] google drive should be a display ?
+- [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
+- [ ] menus refactor
+  - [ ] open 2 menus at once
+  - [ ] maybe use the same system as preview, create them on the fly
+  - [ ] attach menus to tab, where they belong
+  - [ ] leaving left menu shouldn't reset right menu
 - [ ] replace tuikit by ratatui + crossterm
 - [ ] Focus & mouseover. Mousemove require raw terminal mode.. Requires to rewrite every event (Mousepress, mouse release etc.)
       Another motivation to switch to ratatui + crossterm.

--- a/development.md
+++ b/development.md
@@ -1116,7 +1116,15 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
 - [x] Fix attempt of docs. Don't panic in build if no config file is found. That was dumb
 - [x] Fix: Tree mode, when path is root, header is wrong
-- [ ] video slideshow
+- [ ] Preview refactor
+  - [x] mod for ueberzug
+  - [x] builder for ueberzug
+  - [x] creator for thumbnail
+  - [x] video slideshow
+  - [ ] BUG: ueberzug creation may crash the app (poison lock etc.) `Error: Error locking status: poisoned lock: another task failed inside`
+  - [x] preview builder
+  - [ ] preview refactor
+  - [ ] simplify the mess as much as possible
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1111,7 +1111,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 #### Changelog
 
 - [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
-- [ ] refactor path reducer
+  - [ ] refactor path reducer
 - [ ] Bug: when ".." is selected, header path is wrong. This is a big one...
 
 ## TODO

--- a/development.md
+++ b/development.md
@@ -1130,7 +1130,9 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [ ] preview refactor
     - [ ] enum Preview -> struct Preview {kind: kind, content: window+selectable+draw}
   - [ ] simplify the mess as much as possible
-- [ ] flagged should be a menu ?
+- [x] flagged should be a menu
+  - [x] use a menu to display flagged files
+  - [x] display binds
 - [ ] google drive should be a display ?
 
 ## TODO

--- a/development.md
+++ b/development.md
@@ -1112,6 +1112,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 
 - [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
 - [ ] refactor path reducer
+- [ ] Bug: when ".." is selected, header path is wrong. This is a big one...
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1111,6 +1111,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 #### Changelog
 
 - [ ] status, tab, event exec refactor. What should go where ? status is too big and should be splitted
+- [ ] refactor path reducer
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1127,6 +1127,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview symlink to folder as the target
   - [x] preview symlink to files as the target. Must change PreviewBuilder completely
   - [ ] preview refactor
+    - [ ] enum Preview -> struct Preview {kind: kind, content: window+selectable+draw}
   - [ ] simplify the mess as much as possible
 
 ## TODO

--- a/development.md
+++ b/development.md
@@ -1125,7 +1125,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview builder
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible
-- [ ] Focus & mouseover
+- [ ] Focus & mouseover. Demande de passer le terminal en mode raw et réécrire tous les events de souris
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1129,6 +1129,8 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [ ] preview refactor
     - [ ] enum Preview -> struct Preview {kind: kind, content: window+selectable+draw}
   - [ ] simplify the mess as much as possible
+- [ ] flagged should be a menu ?
+- [ ] google drive should be a display ?
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1125,7 +1125,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] Fix: ueberzug creation may crash the app (poison lock etc.) `Error: Error locking status: poisoned lock: another task failed inside`
   - [x] preview builder
   - [x] preview symlink to folder as the target
-  - [ ] preview symlink to files as the target. More difficult, must change PreviewBuilder completely
+  - [x] preview symlink to files as the target. Must change PreviewBuilder completely
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible
 

--- a/development.md
+++ b/development.md
@@ -1121,7 +1121,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] builder for ueberzug
   - [x] creator for thumbnail
   - [x] video slideshow
-  - [ ] BUG: ueberzug creation may crash the app (poison lock etc.) `Error: Error locking status: poisoned lock: another task failed inside`
+  - [x] Fix: ueberzug creation may crash the app (poison lock etc.) `Error: Error locking status: poisoned lock: another task failed inside`
   - [x] preview builder
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible

--- a/development.md
+++ b/development.md
@@ -1100,6 +1100,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] Fix: opening tree mode with selection on "." doesn't display "." as selected
 - [x] refactor draw tree line
 - [x] Fix: Crash when quiting. "sending on a closed channel". From quit -> refresher::quit
+- [ ]
 - [ ] Badges to latest version
 
 ## Current dev
@@ -1107,6 +1108,12 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 ### Version 0.1.29
 
 #### Summary
+
+- Fixed the documentation and updated the badges
+- Flagged files are now displayed in a menu instead of the main window. You can still jump to them, removed them individually
+- Fix jump mode (Alt+g) to allow paths to file. It will jump there and select the file.
+- Preview valid symlink as their target. Broken symlink aren't previewed at all
+- Fixed a few bugs. See details below.
 
 #### Changelog
 

--- a/development.md
+++ b/development.md
@@ -1141,6 +1141,9 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] display binds
 - [x] refactor context menu "more info" into a struct with explicit methods
 - [ ] google drive should be a display ?
+- [ ] don't use ANSI colors
+  - [ ] config
+  - [ ] src
 
 ## TODO
 

--- a/development.md
+++ b/development.md
@@ -1125,10 +1125,13 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] preview builder
   - [ ] preview refactor
   - [ ] simplify the mess as much as possible
-- [ ] Focus & mouseover. Demande de passer le terminal en mode raw et réécrire tous les events de souris
+- [ ] preview symlink to folder as the target
 
 ## TODO
 
+- [ ] replace tuikit by ratatui + crossterm
+- [ ] Focus & mouseover. Mousemove require raw terminal mode.. Requires to rewrite every event (Mousepress, mouse release etc.)
+      Another motivation to switch to ratatui + crossterm.
 - [ ] ideas from broot : https://dystroy.org/broot/#apply-commands-on-several-files
 - [ ] floating windows ?
 - [ ] rclone

--- a/development.md
+++ b/development.md
@@ -1139,6 +1139,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
 - [x] flagged should be a menu
   - [x] use a menu to display flagged files
   - [x] display binds
+- [x] refactor context menu "more info" into a struct with explicit methods
 - [ ] google drive should be a display ?
 
 ## TODO

--- a/development.md
+++ b/development.md
@@ -1114,6 +1114,7 @@ New view: Tree ! Toggle with 't', fold with 'z'. Navigate normally.
   - [x] refactor path reducer
 - [x] Fix: when ".." is selected, header path is wrong. This is a big one...
 - [x] Fix: directory mode when path is root, header is wrong, should just be "/""run" not "/""/run"
+- [x] Fix attempt of docs. Don't panic in build if no config file is found. That was dumb
 - [ ] Bug: Tree mode, when path is root, header is wrong
 
 ## TODO

--- a/src/app/application.rs
+++ b/src/app/application.rs
@@ -11,7 +11,7 @@ use crate::app::Displayer;
 use crate::app::Refresher;
 use crate::app::Status;
 use crate::common::CONFIG_PATH;
-use crate::common::{clear_tmp_file, init_term};
+use crate::common::{clear_tmp_files, init_term};
 use crate::config::cloud_config;
 use crate::config::load_config;
 use crate::config::set_configurable_static;
@@ -180,7 +180,7 @@ impl FM {
     /// May fail if the terminal crashes
     /// May also fail if the thread running in [`crate::app::Refresher`] crashed
     pub fn quit(self) -> Result<String> {
-        clear_tmp_file();
+        clear_tmp_files();
         drop(self.event_reader);
         drop(self.event_dispatcher);
         self.displayer.quit();

--- a/src/app/header_footer.rs
+++ b/src/app/header_footer.rs
@@ -3,13 +3,12 @@ mod inner {
 
     use crate::app::{Status, Tab};
     use crate::common::{
-        UtfWidth, HELP_FIRST_SENTENCE, HELP_SECOND_SENTENCE, LOG_FIRST_SENTENCE,
+        PathShortener, UtfWidth, HELP_FIRST_SENTENCE, HELP_SECOND_SENTENCE, LOG_FIRST_SENTENCE,
         LOG_SECOND_SENTENCE,
     };
     use crate::event::ActionMap;
     use crate::modes::{
-        shorten_path, ColoredText, Content, Display, FileInfo, FilterKind, Preview, Search,
-        Selectable, TextKind,
+        ColoredText, Content, Display, FileInfo, FilterKind, Preview, Search, Selectable, TextKind,
     };
 
     #[derive(Clone, Copy)]
@@ -146,7 +145,12 @@ mod inner {
 
         fn elem_shorten_path(tab: &Tab, left: usize) -> Result<ClickableString> {
             Ok(ClickableString::new(
-                format!(" {}", shorten_path(&tab.directory.path, None)?),
+                format!(
+                    " {}",
+                    PathShortener::path(&tab.directory.path)
+                        .context("Couldn't parse path")?
+                        .shorten()
+                ),
                 HorizontalAlign::Left,
                 ActionMap::Cd,
                 left,
@@ -157,8 +161,10 @@ mod inner {
             let text = match tab.display_mode {
                 Display::Tree => format!(
                     "/{rel}",
-                    rel =
-                        shorten_path(tab.tree.selected_path_relative_to_root()?, Some(width / 2))?
+                    rel = PathShortener::path(tab.tree.selected_path_relative_to_root()?)
+                        .context("Couldn't parse path")?
+                        .with_size(width / 2)
+                        .shorten()
                 ),
                 _ => {
                     if let Some(fileinfo) = tab.directory.selected() {

--- a/src/app/header_footer.rs
+++ b/src/app/header_footer.rs
@@ -144,6 +144,7 @@ mod inner {
         }
 
         fn elem_shorten_path(tab: &Tab, left: usize) -> Result<ClickableString> {
+            tab.directory.is_dotdot_selected();
             Ok(ClickableString::new(
                 format!(
                     " {}",
@@ -167,7 +168,9 @@ mod inner {
                         .shorten()
                 ),
                 _ => {
-                    if let Some(fileinfo) = tab.directory.selected() {
+                    if tab.directory.is_dotdot_selected() {
+                        "".to_owned()
+                    } else if let Some(fileinfo) = tab.directory.selected() {
                         fileinfo.filename_without_dot_dotdot()
                     } else {
                         "".to_owned()

--- a/src/app/header_footer.rs
+++ b/src/app/header_footer.rs
@@ -12,7 +12,7 @@ mod inner {
     };
 
     #[derive(Clone, Copy)]
-    pub enum HorizontalAlign {
+    pub enum Align {
         Left,
         Right,
     }
@@ -35,11 +35,11 @@ mod inner {
         /// It calculates its position with `col` and `align`.
         /// If left aligned, the text size will be added to `col` and the text will span from col to col + width.
         /// otherwise, the text will spawn from col - width to col.
-        fn new(text: String, align: HorizontalAlign, action: ActionMap, col: usize) -> Self {
+        fn new(text: String, align: Align, action: ActionMap, col: usize) -> Self {
             let width = text.utf_width();
             let (left, right) = match align {
-                HorizontalAlign::Left => (col, col + width),
-                HorizontalAlign::Right => (col - width - 3, col - 3),
+                Align::Left => (col, col + width),
+                Align::Right => (col - width - 3, col - 3),
             };
             Self {
                 text,
@@ -152,7 +152,7 @@ mod inner {
                         .context("Couldn't parse path")?
                         .shorten()
                 ),
-                HorizontalAlign::Left,
+                Align::Left,
                 ActionMap::Cd,
                 left,
             ))
@@ -179,28 +179,18 @@ mod inner {
             };
             Ok(ClickableString::new(
                 text,
-                HorizontalAlign::Left,
+                Align::Left,
                 ActionMap::Rename,
                 left,
             ))
         }
 
         fn elem_search(search: &Search, right: usize) -> ClickableString {
-            ClickableString::new(
-                search.to_string(),
-                HorizontalAlign::Right,
-                ActionMap::Search,
-                right,
-            )
+            ClickableString::new(search.to_string(), Align::Right, ActionMap::Search, right)
         }
 
         fn elem_filter(filter: &FilterKind, right: usize) -> ClickableString {
-            ClickableString::new(
-                format!(" {filter}"),
-                HorizontalAlign::Right,
-                ActionMap::Filter,
-                right,
-            )
+            ClickableString::new(format!(" {filter}"), Align::Right, ActionMap::Filter, right)
         }
     }
 
@@ -267,7 +257,7 @@ mod inner {
             for (index, string) in padded_strings.iter().enumerate() {
                 let elem = ClickableString::new(
                     string.to_owned(),
-                    HorizontalAlign::Left,
+                    Align::Left,
                     Self::FOOTER_ACTIONS[index].to_owned(),
                     left,
                 );
@@ -375,7 +365,7 @@ mod inner {
         fn make_elems(status: &Status, width: usize) -> Vec<ClickableString> {
             let title = ClickableString::new(
                 "Fuzzy files".to_owned(),
-                HorizontalAlign::Left,
+                Align::Left,
                 Self::ACTIONS[0].to_owned(),
                 0,
             );
@@ -389,7 +379,7 @@ mod inner {
                     .unwrap_or(&std::path::PathBuf::new())
                     .to_string_lossy()
                     .to_string(),
-                HorizontalAlign::Left,
+                Align::Left,
                 Self::ACTIONS[1].to_owned(),
                 left,
             );
@@ -441,7 +431,7 @@ mod inner {
             for (index, string) in padded_strings.iter().enumerate() {
                 let elem = ClickableString::new(
                     string.to_owned(),
-                    HorizontalAlign::Left,
+                    Align::Left,
                     Self::ACTIONS[index].to_owned(),
                     left,
                 );
@@ -472,19 +462,12 @@ mod inner {
             Self::pair_to_clickable(&pairs, width)
         }
 
-        fn pair_to_clickable(
-            pairs: &[(String, HorizontalAlign)],
-            width: usize,
-        ) -> Vec<ClickableString> {
+        fn pair_to_clickable(pairs: &[(String, Align)], width: usize) -> Vec<ClickableString> {
             let mut left = 0;
             let mut right = width;
             let mut elems = vec![];
             for (text, align) in pairs.iter() {
-                let pos = if let HorizontalAlign::Left = align {
-                    left
-                } else {
-                    right
-                };
+                let pos = if let Align::Left = align { left } else { right };
                 let elem = ClickableString::new(
                     text.to_owned(),
                     align.to_owned(),
@@ -492,10 +475,10 @@ mod inner {
                     pos,
                 );
                 match align {
-                    HorizontalAlign::Left => {
+                    Align::Left => {
                         left += elem.width();
                     }
-                    HorizontalAlign::Right => {
+                    Align::Right => {
                         right -= elem.width();
                     }
                 }
@@ -504,7 +487,7 @@ mod inner {
             elems
         }
 
-        fn strings(status: &Status, tab: &Tab) -> Vec<(String, HorizontalAlign)> {
+        fn strings(status: &Status, tab: &Tab) -> Vec<(String, Align)> {
             match &tab.preview {
                 Preview::Text(text_content) => match text_content.kind {
                     TextKind::HELP => Self::make_help(),
@@ -516,30 +499,30 @@ mod inner {
             }
         }
 
-        fn make_help() -> Vec<(String, HorizontalAlign)> {
+        fn make_help() -> Vec<(String, Align)> {
             vec![
-                (HELP_FIRST_SENTENCE.to_owned(), HorizontalAlign::Left),
+                (HELP_FIRST_SENTENCE.to_owned(), Align::Left),
                 (
                     format!(" Version: {v} ", v = std::env!("CARGO_PKG_VERSION")),
-                    HorizontalAlign::Left,
+                    Align::Left,
                 ),
-                (HELP_SECOND_SENTENCE.to_owned(), HorizontalAlign::Right),
+                (HELP_SECOND_SENTENCE.to_owned(), Align::Right),
             ]
         }
 
-        fn make_log() -> Vec<(String, HorizontalAlign)> {
+        fn make_log() -> Vec<(String, Align)> {
             vec![
-                (LOG_FIRST_SENTENCE.to_owned(), HorizontalAlign::Left),
-                (LOG_SECOND_SENTENCE.to_owned(), HorizontalAlign::Right),
+                (LOG_FIRST_SENTENCE.to_owned(), Align::Left),
+                (LOG_SECOND_SENTENCE.to_owned(), Align::Right),
             ]
         }
 
-        fn make_colored_text(colored_text: &ColoredText) -> Vec<(String, HorizontalAlign)> {
+        fn make_colored_text(colored_text: &ColoredText) -> Vec<(String, Align)> {
             vec![
-                (" Command: ".to_owned(), HorizontalAlign::Left),
+                (" Command: ".to_owned(), Align::Left),
                 (
                     format!(" {command} ", command = colored_text.title()),
-                    HorizontalAlign::Right,
+                    Align::Right,
                 ),
             ]
         }
@@ -552,9 +535,9 @@ mod inner {
             }
         }
 
-        fn make_default_preview(status: &Status, tab: &Tab) -> Vec<(String, HorizontalAlign)> {
+        fn make_default_preview(status: &Status, tab: &Tab) -> Vec<(String, Align)> {
             if let Ok(fileinfo) = Self::_pick_previewed_fileinfo(status) {
-                let mut strings = vec![(" Preview ".to_owned(), HorizontalAlign::Left)];
+                let mut strings = vec![(" Preview ".to_owned(), Align::Left)];
                 if !tab.preview.is_empty() {
                     let index = match &tab.preview {
                         Preview::Ueberzug(image) => image.index + 1,
@@ -562,16 +545,13 @@ mod inner {
                     };
                     strings.push((
                         format!(" {index} / {len} ", len = tab.preview.len()),
-                        HorizontalAlign::Right,
+                        Align::Right,
                     ));
                 };
-                strings.push((
-                    format!(" {} ", fileinfo.path.display()),
-                    HorizontalAlign::Left,
-                ));
+                strings.push((format!(" {} ", fileinfo.path.display()), Align::Left));
                 strings
             } else {
-                vec![("".to_owned(), HorizontalAlign::Left)]
+                vec![("".to_owned(), Align::Left)]
             }
         }
 

--- a/src/app/header_footer.rs
+++ b/src/app/header_footer.rs
@@ -8,7 +8,7 @@ mod inner {
     };
     use crate::event::ActionMap;
     use crate::modes::{
-        ColoredText, Content, Display, FileInfo, FilterKind, Preview, Search, Selectable, TextKind,
+        Content, Display, FileInfo, FilterKind, Preview, Search, Selectable, Text, TextKind,
     };
 
     #[derive(Clone, Copy)]
@@ -500,11 +500,11 @@ mod inner {
         fn strings(status: &Status, tab: &Tab) -> Vec<(String, Align)> {
             match &tab.preview {
                 Preview::Text(text_content) => match text_content.kind {
-                    TextKind::HELP => Self::make_help(),
-                    TextKind::LOG => Self::make_log(),
+                    TextKind::CliInfo => Self::make_colored_text(text_content),
+                    TextKind::Help => Self::make_help(),
+                    TextKind::Log => Self::make_log(),
                     _ => Self::make_default_preview(status, tab),
                 },
-                Preview::ColoredText(colored_text) => Self::make_colored_text(colored_text),
                 _ => Self::make_default_preview(status, tab),
             }
         }
@@ -527,11 +527,11 @@ mod inner {
             ]
         }
 
-        fn make_colored_text(colored_text: &ColoredText) -> Vec<(String, Align)> {
+        fn make_colored_text(colored_text: &Text) -> Vec<(String, Align)> {
             vec![
                 (" Command: ".to_owned(), Align::Left),
                 (
-                    format!(" {command} ", command = colored_text.title()),
+                    format!(" {command} ", command = colored_text.title),
                     Align::Right,
                 ),
             ]

--- a/src/app/header_footer.rs
+++ b/src/app/header_footer.rs
@@ -144,7 +144,6 @@ mod inner {
         }
 
         fn elem_shorten_path(tab: &Tab, left: usize) -> Result<ClickableString> {
-            tab.directory.is_dotdot_selected();
             Ok(ClickableString::new(
                 format!(
                     " {}",

--- a/src/app/internal_settings.rs
+++ b/src/app/internal_settings.rs
@@ -6,7 +6,7 @@ use indicatif::InMemoryTerm;
 use sysinfo::Disks;
 use tuikit::term::Term;
 
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 use crate::common::NVIM;
 use crate::common::SS;
 use crate::io::execute_and_output;
@@ -84,7 +84,7 @@ impl InternalSettings {
     }
 
     fn parse_nvim_address_from_ss_output() -> Result<String> {
-        if !is_program_in_path(SS) {
+        if !is_in_path(SS) {
             return Err(anyhow!("{SS} isn't installed"));
         }
         if let Ok(output) = execute_and_output(SS, ["-l"]) {

--- a/src/app/internal_settings.rs
+++ b/src/app/internal_settings.rs
@@ -101,7 +101,7 @@ impl InternalSettings {
     }
 
     /// Remove the top of the copy queue.
-    pub fn file_copied(&mut self) -> Result<()> {
+    pub fn copy_file_remove_head(&mut self) -> Result<()> {
         if self.copy_file_queue.is_empty() {
             Err(anyhow!("Copy File Pool is empty"))
         } else {

--- a/src/app/internal_settings.rs
+++ b/src/app/internal_settings.rs
@@ -6,12 +6,8 @@ use indicatif::InMemoryTerm;
 use sysinfo::Disks;
 use tuikit::term::Term;
 
-use crate::common::is_in_path;
-use crate::common::NVIM;
-use crate::common::SS;
-use crate::io::execute_and_output;
-use crate::io::Args;
-use crate::io::Opener;
+use crate::common::{is_in_path, NVIM, SS};
+use crate::io::{execute_and_output, Args, Opener};
 
 pub struct InternalSettings {
     /// Do we have to clear the screen ?

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -3,8 +3,7 @@ use std::fs::File;
 use serde::Serialize;
 use serde_yml::{from_reader, to_writer, Error as YamlError, Value as YamlValue};
 
-use crate::common::tilde;
-use crate::common::SESSION_PATH;
+use crate::common::{tilde, SESSION_PATH};
 use crate::io::MIN_WIDTH_FOR_DUAL_PANE;
 use crate::log_info;
 

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -1443,7 +1443,7 @@ impl Status {
             &self.tabs[self.index].users,
         )?;
         if let Display::Tree = self.current_tab().display_mode {
-            self.current_tab_mut().make_tree(None)?;
+            self.current_tab_mut().make_tree(None);
         }
         let len = self.current_tab().directory.content.len();
         self.current_tab_mut().window.reset(len);

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -10,50 +10,24 @@ use sysinfo::{Disk, Disks};
 use tuikit::prelude::{from_keyname, Event};
 use tuikit::term::Term;
 
-use crate::app::ClickableLine;
-use crate::app::Footer;
-use crate::app::Header;
-use crate::app::InternalSettings;
-use crate::app::Session;
-use crate::app::Tab;
+use crate::app::{ClickableLine, Footer, Header, InternalSettings, Session, Tab};
 use crate::common::{
-    args_is_empty, disk_used_by_path, filename_from_path, is_sudo_command, open_in_current_neovim,
-    path_to_string, row_to_window_index,
+    args_is_empty, current_username, disk_space, disk_used_by_path, filename_from_path, is_in_path,
+    is_sudo_command, open_in_current_neovim, path_to_string, row_to_window_index,
 };
-use crate::common::{current_username, disk_space, is_in_path};
 use crate::config::{Bindings, START_FOLDER};
 use crate::event::FmEvents;
-use crate::io::Opener;
-use crate::io::{execute_and_capture_output_with_path, Args};
 use crate::io::{
-    execute_and_capture_output_without_check, execute_sudo_command_with_password,
-    reset_sudo_faillock,
+    execute_and_capture_output_with_path, execute_and_capture_output_without_check,
+    execute_sudo_command_with_password, get_cloud_token_names, google_drive, reset_sudo_faillock,
+    Args, Extension, Internal, Kind, Opener, MIN_WIDTH_FOR_DUAL_PANE,
 };
-use crate::io::{get_cloud_token_names, Internal};
-use crate::io::{google_drive, MIN_WIDTH_FOR_DUAL_PANE};
-use crate::io::{Extension, Kind};
-use crate::modes::MountRepr;
-use crate::modes::NeedConfirmation;
-use crate::modes::PasswordKind;
-use crate::modes::PasswordUsage;
-use crate::modes::Permissions;
-use crate::modes::Preview;
-use crate::modes::Selectable;
-use crate::modes::ShellCommandParser;
-use crate::modes::Skimer;
-use crate::modes::To;
-use crate::modes::Tree;
-use crate::modes::Users;
-use crate::modes::{copy_move, regex_matcher};
-use crate::modes::{extract_extension, Edit};
-use crate::modes::{BlockDeviceAction, Navigate};
-use crate::modes::{Content, FileInfo};
-use crate::modes::{ContentWindow, CopyMove};
-use crate::modes::{Display, Go};
-use crate::modes::{FileKind, Menu};
-use crate::modes::{FilterKind, InputSimple};
-use crate::modes::{IsoDevice, PickerCaller};
-use crate::modes::{MountCommands, PreviewBuilder};
+use crate::modes::{
+    copy_move, extract_extension, regex_matcher, BlockDeviceAction, Content, ContentWindow,
+    CopyMove, Display, Edit, FileInfo, FileKind, FilterKind, Go, InputSimple, IsoDevice, Menu,
+    MountCommands, MountRepr, Navigate, NeedConfirmation, PasswordKind, PasswordUsage, Permissions,
+    PickerCaller, Preview, PreviewBuilder, Selectable, ShellCommandParser, Skimer, To, Tree, Users,
+};
 use crate::{log_info, log_line};
 
 pub enum Window {

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -543,7 +543,7 @@ impl Status {
                 FileInfo::new(shortcut_path, users)
             }
             Focus::LeftMenu if matches!(left_tab.edit_mode, Edit::Navigate(Navigate::History)) => {
-                let (history_path, _) = &left_tab.history.content()[left_tab.history.index()];
+                let history_path = &left_tab.history.content()[left_tab.history.index()];
                 FileInfo::new(history_path, users)
             }
             _ => left_tab.current_file(),

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -774,6 +774,19 @@ impl Status {
         self.clear_flags_and_reset_view()
     }
 
+    pub fn copy_next_file_in_queue(&mut self) -> Result<()> {
+        let (sources, dest) = self.internal_settings.copy_file_queue[0].clone();
+        let in_mem = copy_move(
+            crate::modes::CopyMove::Copy,
+            sources,
+            dest,
+            self.internal_settings.term.clone(),
+            std::sync::Arc::clone(&self.fm_sender),
+        )?;
+        self.internal_settings.store_copy_progress(in_mem);
+        Ok(())
+    }
+
     fn skim_init(&mut self) {
         self.skimer = Some(Skimer::new(Arc::clone(&self.internal_settings.term)));
     }

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -18,7 +18,7 @@ use crate::app::Session;
 use crate::app::Tab;
 use crate::common::{
     args_is_empty, disk_used_by_path, filename_from_path, is_sudo_command, open_in_current_neovim,
-    path_to_config_folder, path_to_string, row_to_window_index,
+    path_to_string, row_to_window_index,
 };
 use crate::common::{current_username, disk_space, is_in_path};
 use crate::config::{Bindings, START_FOLDER};

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -21,7 +21,7 @@ use crate::common::{
     args_is_empty, disk_used_by_path, filename_from_path, is_sudo_command, open_in_current_neovim,
     path_to_config_folder, path_to_string, row_to_window_index,
 };
-use crate::common::{current_username, disk_space, is_program_in_path};
+use crate::common::{current_username, disk_space, is_in_path};
 use crate::config::{Bindings, START_FOLDER};
 use crate::event::FmEvents;
 use crate::io::Internal;
@@ -298,9 +298,9 @@ impl Status {
                 if matches!(self.current_tab().display_mode, Display::Flagged) {
                     self.menu.flagged.select_row(row)
                 } else if self.has_clicked_on_second_pane_preview() {
-                    if let Preview::Tree(tree_preview) = &self.tabs[1].preview {
+                    if let Preview::Tree(tree) = &self.tabs[1].preview {
                         let index = row_to_window_index(row) + self.tabs[1].window.top;
-                        let path = &tree_preview.tree.path_from_index(index)?;
+                        let path = &tree.path_from_index(index)?;
                         self.tabs[0].cd_to_file(path)?;
                         self.index = 0;
                         self.focus = Focus::LeftFile;
@@ -1162,7 +1162,7 @@ impl Status {
             self.ask_password(None, PasswordUsage::SUDOCOMMAND)?;
             Ok(false)
         } else {
-            if !is_program_in_path(&executable) {
+            if !is_in_path(&executable) {
                 return Ok(true);
             }
             let current_directory = self.current_tab().directory_of_selected()?.to_owned();

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -525,7 +525,7 @@ impl Status {
         };
         let left_tab = &self.tabs[0];
         let users = &left_tab.users;
-        self.tabs[1].preview = PreviewBuilder::new(&fileinfo, users)
+        self.tabs[1].preview = PreviewBuilder::new(&fileinfo.path, users)
             .build()
             .unwrap_or_default();
         self.tabs[1].window.reset(self.tabs[1].preview.len());

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -1440,8 +1440,7 @@ impl Status {
     }
 
     pub fn fuzzy_flags(&mut self) -> Result<()> {
-        self.set_edit_mode(self.index, Edit::Navigate(Navigate::Flagged));
-        Ok(())
+        self.set_edit_mode(self.index, Edit::Navigate(Navigate::Flagged))
     }
 
     pub fn sort(&mut self, c: char) -> Result<()> {

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -679,6 +679,18 @@ impl Status {
         }
     }
 
+    pub fn jump_flagged(&mut self) -> Result<()> {
+        let Some(path) = self.menu.flagged.selected() else {
+            return Ok(());
+        };
+        let path = path.to_owned();
+        let tab = self.current_tab_mut();
+        tab.set_display_mode(Display::Directory);
+        tab.refresh_view()?;
+        tab.jump(path)?;
+        self.update_second_pane_for_preview()
+    }
+
     /// Execute a move or a copy of the flagged files to current directory.
     /// A progress bar is displayed (invisible for small files) and a notification
     /// is sent every time, even for 0 bytes files...

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -417,6 +417,35 @@ impl Status {
         Ok(())
     }
 
+    /// Leave an edit mode and refresh the menu.
+    /// It should only be called when edit mode isn't nothing.
+    pub fn leave_edit_mode(&mut self) -> Result<()> {
+        if matches!(
+            self.current_tab().edit_mode,
+            Edit::InputSimple(InputSimple::Filter)
+        ) {
+            self.current_tab_mut().settings.reset_filter()
+        }
+        if self.reset_edit_mode()? {
+            self.current_tab_mut().refresh_view()?;
+        } else {
+            self.current_tab_mut().refresh_params();
+        }
+        Ok(())
+    }
+
+    /// Leave the preview or flagged display mode.
+    /// Should only be called when :
+    /// 1. No menu is opened
+    ///
+    /// AND
+    ///
+    /// 2. Display mode is preview or flagged.
+    pub fn leave_preview_flagged(&mut self) -> Result<()> {
+        self.current_tab_mut().set_display_mode(Display::Directory);
+        self.current_tab_mut().refresh_and_reselect_file()
+    }
+
     /// Reset the edit mode to "Nothing" (closing any menu) and returns
     /// true if the display should be refreshed.
     pub fn reset_edit_mode(&mut self) -> Result<bool> {

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -654,7 +654,7 @@ impl Status {
                 Display::Tree => {
                     self.menu.flagged.toggle(&file.path);
                     if !self.tabs[self.index].tree.selected_is_last() {
-                        let _ = self.current_tab_mut().tree_select_next();
+                        self.current_tab_mut().tree_select_next();
                     }
                     let _ = self.update_second_pane_for_preview();
                 }

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -9,7 +9,7 @@ use crate::common::{
     has_last_modification_happened_less_than, path_to_string, row_to_window_index,
 };
 use crate::config::START_FOLDER;
-use crate::io::{Args, Opener};
+use crate::io::Args;
 use crate::log_info;
 use crate::modes::{
     Content, ContentWindow, Directory, Display, Edit, FileInfo, FileKind, FilterKind, Go, History,
@@ -726,12 +726,5 @@ impl Tab {
             self.search.set_index_paths(index, paths);
             self.go_to_file(path);
         }
-    }
-
-    pub fn context_info(&self, opener: &Opener) -> Vec<String> {
-        let Ok(selected) = self.current_file() else {
-            return vec![];
-        };
-        selected.context_info(opener)
     }
 }

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -186,7 +186,6 @@ impl Tab {
             Display::Tree => self.tree.display_len(),
             Display::Preview => self.preview.len(),
             Display::Directory => self.directory.len(),
-            Display::Flagged => 0,
         }
     }
 
@@ -237,7 +236,6 @@ impl Tab {
                 has_last_modification_happened_less_than(&self.directory.path, 10)?
             }
             Display::Tree => self.tree.has_modified_dirs(),
-            Display::Flagged => false, // TODO! what to do ????,
         } {
             self.refresh_and_reselect_file()
         } else {
@@ -359,7 +357,6 @@ impl Tab {
                 let index = self.tree.displayable().index();
                 self.scroll_to(index);
             }
-            Display::Flagged => (),
         }
     }
 
@@ -442,7 +439,7 @@ impl Tab {
     /// Add the last path to the history of visited paths.
     /// Does nothing in preview or flagged display mode.
     pub fn cd(&mut self, path: &path::Path) -> Result<()> {
-        if matches!(self.display_mode, Display::Preview | Display::Flagged) {
+        if matches!(self.display_mode, Display::Preview) {
             return Ok(());
         }
         self.search.reset_paths();
@@ -467,7 +464,7 @@ impl Tab {
     }
 
     pub fn back(&mut self) -> Result<()> {
-        if matches!(self.display_mode, Display::Preview | Display::Flagged) {
+        if matches!(self.display_mode, Display::Preview) {
             return Ok(());
         }
         if self.history.content.is_empty() {
@@ -507,10 +504,6 @@ impl Tab {
             Display::Preview => return Ok(()),
             Display::Directory => self.jump_directory(&jump_target, target_dir)?,
             Display::Tree => self.jump_tree(&jump_target, target_dir)?,
-            Display::Flagged => {
-                self.set_display_mode(Display::Directory);
-                self.jump(jump_target)?;
-            }
         }
         Ok(())
     }

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -368,6 +368,21 @@ impl Tab {
         self.refresh_view()
     }
 
+    pub fn reset_my_files(&mut self) -> Result<()> {
+        self.directory.reset_files(&self.settings, &self.users)
+    }
+
+    pub fn set_filter(&mut self, filter: FilterKind) -> Result<()> {
+        self.settings.set_filter(filter);
+        self.reset_my_files()?;
+        if let Display::Tree = self.display_mode {
+            self.make_tree(None);
+        }
+        let len = self.directory.content.len();
+        self.window.reset(len);
+        Ok(())
+    }
+
     /// Set the height of the window and itself.
     pub fn set_height(&mut self, height: usize) {
         self.window.set_height(height);

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -450,8 +450,7 @@ impl Tab {
                 return Ok(());
             }
         }
-        self.history
-            .push(&self.directory.path, &self.current_file()?.path);
+        self.history.push(&self.current_file()?.path);
         self.directory
             .change_directory(path, &self.settings, &self.users)?;
         if matches!(self.display_mode, Display::Tree) {
@@ -470,12 +469,11 @@ impl Tab {
         if self.history.content.is_empty() {
             return Ok(());
         }
-        let Some((path, file)) = self.history.content.pop() else {
+        let Some(file) = self.history.content.pop() else {
             return Ok(());
         };
         self.history.content.pop();
-        self.cd(&path)?;
-        self.go_to_file(file);
+        self.cd_to_file(&file)?;
         Ok(())
     }
 

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -269,6 +269,14 @@ impl Tab {
         Ok(())
     }
 
+    fn make_tree_for_parent(&mut self) -> Result<()> {
+        let Some(parent) = self.tree.root_path().parent() else {
+            return Ok(());
+        };
+        self.cd(parent.to_owned().as_ref())?;
+        self.make_tree(Some(self.settings.sort_kind))
+    }
+
     /// Enter or leave display tree mode.
     pub fn toggle_tree_mode(&mut self) -> Result<()> {
         let current_file = self.current_file()?;
@@ -594,11 +602,7 @@ impl Tab {
     /// If we were at the root node, move to the parent and make a new tree.
     pub fn tree_select_parent(&mut self) -> Result<()> {
         if self.tree.is_on_root() {
-            let Some(parent) = self.tree.root_path().parent() else {
-                return Ok(());
-            };
-            self.cd(parent.to_owned().as_ref())?;
-            self.make_tree(Some(self.settings.sort_kind))?;
+            self.make_tree_for_parent()?;
         } else {
             self.tree.go(To::Parent);
         }
@@ -619,24 +623,21 @@ impl Tab {
     }
 
     /// Select the next sibling.
-    pub fn tree_select_next(&mut self) -> Result<()> {
+    pub fn tree_select_next(&mut self) {
         self.tree.go(To::Next);
         self.window.scroll_down_one(self.tree.displayable().index());
-        Ok(())
     }
 
     /// Select the previous siblging
-    pub fn tree_select_prev(&mut self) -> Result<()> {
+    pub fn tree_select_prev(&mut self) {
         self.tree.go(To::Prev);
         self.window.scroll_up_one(self.tree.displayable().index());
-        Ok(())
     }
 
     /// Go to the last leaf.
-    pub fn tree_go_to_bottom_leaf(&mut self) -> Result<()> {
+    pub fn tree_go_to_bottom_leaf(&mut self) {
         self.tree.go(To::Last);
         self.window.scroll_to(self.tree.displayable().index());
-        Ok(())
     }
 
     /// Navigate to the next sibling of current file in tree mode.

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -306,9 +306,8 @@ impl Tab {
             return Ok(());
         };
         match file_info.file_kind {
-            FileKind::NormalFile => self.make_preview_unchecked(file_info),
             FileKind::Directory => self.toggle_tree_mode()?,
-            _ => (),
+            _ => self.make_preview_unchecked(file_info),
         }
 
         Ok(())

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -13,7 +13,7 @@ use crate::io::{Args, Opener};
 use crate::log_info;
 use crate::modes::{
     Content, ContentWindow, Directory, Display, Edit, FileInfo, FileKind, FilterKind, Go, History,
-    Preview, Search, Selectable, SortKind, To, Tree, Users,
+    Preview, PreviewBuilder, Search, Selectable, SortKind, To, Tree, Users,
 };
 
 pub struct TabSettings {
@@ -208,7 +208,7 @@ impl Tab {
 
     /// Refresh everything but the view
     pub fn refresh_params(&mut self) {
-        self.preview = Preview::empty();
+        self.preview = PreviewBuilder::empty();
         if matches!(self.display_mode, Display::Tree) {
             self.make_tree(None);
         } else {
@@ -317,7 +317,9 @@ impl Tab {
     /// Creates a preview and assign it.
     /// Doesn't check if it's the correct action to do according to display.
     fn make_preview_unchecked(&mut self, file_info: FileInfo) {
-        let preview = Preview::file(&file_info).unwrap_or_default();
+        let preview = PreviewBuilder::new(&file_info, &self.users)
+            .build()
+            .unwrap_or_default();
         self.set_display_mode(Display::Preview);
         self.window.reset(preview.len());
         self.preview = preview;
@@ -326,7 +328,7 @@ impl Tab {
     /// Reset the preview to empty. Used to save some memory.
     fn reset_preview(&mut self) {
         if matches!(self.display_mode, Display::Preview) {
-            self.preview = Preview::empty();
+            self.preview = PreviewBuilder::empty();
         }
     }
 

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -317,7 +317,7 @@ impl Tab {
     /// Creates a preview and assign it.
     /// Doesn't check if it's the correct action to do according to display.
     fn make_preview_unchecked(&mut self, file_info: FileInfo) {
-        let preview = PreviewBuilder::new(&file_info, &self.users)
+        let preview = PreviewBuilder::new(&file_info.path, &self.users)
             .build()
             .unwrap_or_default();
         self.set_display_mode(Display::Preview);

--- a/src/common/constant_strings_paths.rs
+++ b/src/common/constant_strings_paths.rs
@@ -65,8 +65,6 @@ pub const THUMBNAIL_PATH_PNG: &str = "/tmp/fm_thumbnail.png";
 pub const THUMBNAIL_PATH_JPG: &str = "/tmp/fm_thumbnail.jpg";
 /// Ueberzug image for videos, without extension
 pub const THUMBNAIL_PATH_NO_EXT: &str = "/tmp/fm_thumbnail";
-/// Ueberzug image for pdf
-pub const THUMBNAIL_PDF_PATH: &str = "/tmp/fm_thumbnail";
 /// Libreoffice pdf output
 pub const CALC_PDF_PATH: &str = "/tmp/fm_calc.pdf";
 /// Array of hardcoded shortcuts with standard *nix paths.

--- a/src/common/constant_strings_paths.rs
+++ b/src/common/constant_strings_paths.rs
@@ -211,7 +211,7 @@ pub const CRYPTSETUP: &str = "cryptsetup";
 /// gio is used to mount removable devices
 pub const GIO: &str = "gio";
 /// used to get information about fifo files
-pub const LSOF: &str = "lsof";
+pub const UDEVADM: &str = "udevadm";
 /// neovim executable
 pub const NVIM: &str = "nvim";
 /// bsdtar executable, used to display archive content

--- a/src/common/constant_strings_paths.rs
+++ b/src/common/constant_strings_paths.rs
@@ -63,6 +63,8 @@ pub const LOG_SECOND_SENTENCE: &str = " Last actions affecting the file tree";
 pub const THUMBNAIL_PATH_PNG: &str = "/tmp/fm_thumbnail.png";
 /// Ueberzug image thumbnails
 pub const THUMBNAIL_PATH_JPG: &str = "/tmp/fm_thumbnail.jpg";
+/// Ueberzug image for videos, without extension
+pub const THUMBNAIL_PATH_NO_EXT: &str = "/tmp/fm_thumbnail";
 /// Ueberzug image for pdf
 pub const THUMBNAIL_PDF_PATH: &str = "/tmp/fm_thumbnail";
 /// Libreoffice pdf output

--- a/src/common/format.rs
+++ b/src/common/format.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+/// Shorten a path to be displayed in 50 chars or less.
+/// Each element of the path is shortened if needed.
+pub struct PathShortener {
+    size: usize,
+    path_str: String,
+}
+
+impl PathShortener {
+    const MAX_PATH_ELEM_SIZE: usize = 50;
+
+    pub fn path(path: &Path) -> Option<Self> {
+        Some(Self {
+            path_str: path.to_str()?.to_owned(),
+            size: Self::MAX_PATH_ELEM_SIZE,
+        })
+    }
+
+    pub fn with_size(mut self, size: usize) -> Self {
+        self.size = size;
+        self
+    }
+
+    pub fn shorten(self) -> String {
+        if self.path_str.len() < self.size {
+            return self.path_str;
+        }
+        self.shorten_long_path()
+    }
+
+    fn shorten_long_path(self) -> String {
+        let splitted_path: Vec<_> = self.path_str.split('/').collect();
+        let size_per_elem = std::cmp::max(1, self.size / (splitted_path.len() + 1)) + 1;
+        Self::elems(splitted_path, size_per_elem).join("/")
+    }
+
+    fn elems(splitted_path: Vec<&str>, size_per_elem: usize) -> Vec<&str> {
+        splitted_path
+            .iter()
+            .filter_map(|p| Self::slice_long(p, size_per_elem))
+            .collect()
+    }
+
+    fn slice_long(p: &str, size_per_elem: usize) -> Option<&str> {
+        if p.len() <= size_per_elem {
+            Some(p)
+        } else {
+            p.get(0..size_per_elem)
+        }
+    }
+}

--- a/src/common/format.rs
+++ b/src/common/format.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use crate::common::UtfWidth;
+
 /// Shorten a path to be displayed in 50 chars or less.
 /// Each element of the path is shortened if needed.
 pub struct PathShortener {
@@ -8,7 +10,7 @@ pub struct PathShortener {
 }
 
 impl PathShortener {
-    const MAX_PATH_ELEM_SIZE: usize = 50;
+    const MAX_PATH_ELEM_SIZE: usize = 80;
 
     pub fn path(path: &Path) -> Option<Self> {
         Some(Self {
@@ -23,7 +25,7 @@ impl PathShortener {
     }
 
     pub fn shorten(self) -> String {
-        if self.path_str.len() < self.size {
+        if self.path_str.utf_width() < self.size {
             return self.path_str;
         }
         self.shorten_long_path()

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,7 +1,9 @@
 mod constant_strings_paths;
+mod format;
 mod random;
 mod utils;
 
 pub use constant_strings_paths::*;
+pub use format::*;
 pub use random::random_alpha_chars;
 pub use utils::*;

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -99,7 +99,7 @@ pub fn current_username() -> Result<String> {
 
 /// True if the program is given by an absolute path which exists or
 /// if the command is available in $PATH.
-pub fn is_program_in_path<S>(program: S) -> bool
+pub fn is_in_path<S>(program: S) -> bool
 where
     S: Into<String> + std::fmt::Display + AsRef<Path>,
 {

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use std::fs::metadata;
 use std::io::BufRead;
 use std::os::unix::fs::MetadataExt;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
@@ -14,13 +13,8 @@ use tuikit::term::Term;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::common::CONFIG_FOLDER;
-use crate::common::{CALC_PDF_PATH, THUMBNAIL_PATH_JPG};
-use crate::log_info;
-use crate::log_line;
-use crate::modes::human_size;
-use crate::modes::nvim;
-use crate::modes::ContentWindow;
-use crate::modes::Users;
+use crate::modes::{human_size, nvim, ContentWindow, Users};
+use crate::{log_info, log_line};
 
 /// Returns a `Display` instance after `tuikit::term::Term` creation.
 pub fn init_term() -> Result<Term> {
@@ -322,10 +316,7 @@ pub trait UtfWidth {
 
 impl UtfWidth for String {
     fn utf_width(&self) -> usize {
-        self.graphemes(true)
-            .map(|s| s.to_string())
-            .collect::<Vec<String>>()
-            .len()
+        self.as_str().utf_width()
     }
 }
 

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -128,6 +128,13 @@ pub fn extract_lines(content: String) -> Vec<String> {
     content.lines().map(|line| line.to_string()).collect()
 }
 
+pub fn get_clipboard() -> Option<String> {
+    let Ok(mut ctx) = ClipboardContext::new() else {
+        return None;
+    };
+    ctx.get_contents().ok()
+}
+
 pub fn set_clipboard(content: String) {
     log_info!("copied to clipboard: {}", content);
     let Ok(mut ctx) = ClipboardContext::new() else {

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -216,9 +216,14 @@ pub fn random_name() -> String {
 }
 
 /// Clear the temporary file used by fm for previewing.
-pub fn clear_tmp_file() {
-    let _ = std::fs::remove_file(THUMBNAIL_PATH_JPG);
-    let _ = std::fs::remove_file(CALC_PDF_PATH);
+pub fn clear_tmp_files() {
+    let Ok(read_dir) = std::fs::read_dir("/tmp") else {
+        return;
+    };
+    read_dir
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with("fm_thumbnail"))
+        .for_each(|e| std::fs::remove_file(e.path()).unwrap_or_default())
 }
 
 /// True if the directory is empty,

--- a/src/config/colors.rs
+++ b/src/config/colors.rs
@@ -1,7 +1,6 @@
 use tuikit::attr::Color;
 
-use crate::config::ARRAY_GRADIENT;
-use crate::config::COLORER;
+use crate::config::{ARRAY_GRADIENT, COLORER};
 
 pub const MAX_GRADIENT_NORMAL: usize = 254;
 

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -102,9 +102,9 @@ pub fn load_config(path: &str) -> Result<Config> {
 /// Reads the config file and parse the "palette" values.
 /// The palette format looks like this (with different accepted format)
 /// ```yaml
-/// palette:
-///   start: yellow, #ffff00, rgb(255, 255, 0)
-///   stop:  #ff00ff
+/// colors:
+///   normal_start: yellow, #ffff00, rgb(255, 255, 0)
+///   normal_stop:  #ff00ff
 /// ```
 /// Recognized formats are : ansi names (yellow, light_red etc.), rgb like rgb(255, 55, 132) and hexadecimal like #ff3388.
 /// The ANSI names are recognized but we can't get the user settings for all kinds of terminal

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -119,10 +119,10 @@ pub fn read_normal_file_colorer() -> (ColorG, ColorG) {
     let Ok(yaml) = from_reader::<File, Value>(file) else {
         return default_pair;
     };
-    let Some(start) = yaml["palette"]["start"].as_str() else {
+    let Some(start) = yaml["colors"]["normal_start"].as_str() else {
         return default_pair;
     };
-    let Some(stop) = yaml["palette"]["stop"].as_str() else {
+    let Some(stop) = yaml["colors"]["normal_stop"].as_str() else {
         return default_pair;
     };
     let Some(start_color) = ColorG::parse_any_color(start) else {
@@ -242,7 +242,7 @@ impl MenuAttrs {
     pub fn update(mut self) -> Self {
         if let Ok(file) = File::open(path::Path::new(&tilde(CONFIG_PATH).to_string())) {
             if let Ok(yaml) = from_reader::<File, Value>(file) {
-                let menu_colors = &yaml["menu_colors"];
+                let menu_colors = &yaml["colors"];
                 update_attr!(self.first, menu_colors, "first");
                 update_attr!(self.second, menu_colors, "second");
                 update_attr!(self.selected_border, menu_colors, "selected_border");

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -243,8 +243,8 @@ impl MenuAttrs {
         if let Ok(file) = File::open(path::Path::new(&tilde(CONFIG_PATH).to_string())) {
             if let Ok(yaml) = from_reader::<File, Value>(file) {
                 let menu_colors = &yaml["colors"];
-                update_attr!(self.first, menu_colors, "first");
-                update_attr!(self.second, menu_colors, "second");
+                update_attr!(self.first, menu_colors, "header_first");
+                update_attr!(self.second, menu_colors, "header_second");
                 update_attr!(self.selected_border, menu_colors, "selected_border");
                 update_attr!(self.inert_border, menu_colors, "inert_border");
                 update_attr!(self.palette_1, menu_colors, "palette_1");

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -2,14 +2,12 @@ use std::{fs::File, path};
 
 use anyhow::Result;
 use serde_yml::{from_reader, Value};
-use tuikit::attr::Attr;
-use tuikit::attr::Color;
+use tuikit::attr::{Attr, Color};
 
-use crate::common::tilde;
-use crate::common::{is_in_path, DEFAULT_TERMINAL_FLAG};
-use crate::common::{CONFIG_PATH, DEFAULT_TERMINAL_APPLICATION};
-use crate::config::Bindings;
-use crate::config::ColorG;
+use crate::common::{
+    is_in_path, tilde, CONFIG_PATH, DEFAULT_TERMINAL_APPLICATION, DEFAULT_TERMINAL_FLAG,
+};
+use crate::config::{Bindings, ColorG};
 use crate::io::color_to_attr;
 
 /// Holds every configurable aspect of the application.

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -6,7 +6,7 @@ use tuikit::attr::Attr;
 use tuikit::attr::Color;
 
 use crate::common::tilde;
-use crate::common::{is_program_in_path, DEFAULT_TERMINAL_FLAG};
+use crate::common::{is_in_path, DEFAULT_TERMINAL_FLAG};
 use crate::common::{CONFIG_PATH, DEFAULT_TERMINAL_APPLICATION};
 use crate::config::Bindings;
 use crate::config::ColorG;
@@ -52,7 +52,7 @@ impl Config {
     /// else nothing is done.
     fn update_terminal(&mut self, yaml: &Value) {
         let terminal_currently_used = std::env::var("TERM").unwrap_or_default();
-        if !terminal_currently_used.is_empty() && is_program_in_path(&terminal_currently_used) {
+        if !terminal_currently_used.is_empty() && is_in_path(&terminal_currently_used) {
             self.terminal = terminal_currently_used
         } else if let Some(configured_terminal) = yaml.as_str() {
             self.terminal = configured_terminal.to_owned()

--- a/src/config/gradient.rs
+++ b/src/config/gradient.rs
@@ -1,8 +1,7 @@
 use anyhow::{anyhow, Result};
 use tuikit::attr::Color;
 
-use crate::config::ColorG;
-use crate::config::MAX_GRADIENT_NORMAL;
+use crate::config::{ColorG, MAX_GRADIENT_NORMAL};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Gradient {

--- a/src/config/oncelock_static.rs
+++ b/src/config/oncelock_static.rs
@@ -7,11 +7,9 @@ use syntect::highlighting::Theme;
 use tuikit::attr::Color;
 
 use crate::common::tilde;
-use crate::config::FileAttr;
-use crate::config::MenuAttrs;
-use crate::config::NormalFileColorer;
-use crate::config::MAX_GRADIENT_NORMAL;
-use crate::config::{read_normal_file_colorer, Gradient};
+use crate::config::{
+    read_normal_file_colorer, FileAttr, Gradient, MenuAttrs, NormalFileColorer, MAX_GRADIENT_NORMAL,
+};
 
 /// Starting folder of the application. Read from arguments if any `-P ~/Downloads` else it uses the current folder: `.`.
 pub static START_FOLDER: OnceLock<PathBuf> = OnceLock::new();

--- a/src/event/event_dispatch.rs
+++ b/src/event/event_dispatch.rs
@@ -132,6 +132,12 @@ impl EventDispatcher {
             Navigate::Cloud if c == 'u' => status.cloud_upload_selected_file(),
             Navigate::Cloud if c == 'x' => status.cloud_enter_delete_mode(),
             Navigate::Cloud if c == '?' => status.cloud_update_metadata(),
+            Navigate::Flagged if c == 'u' => {
+                status.menu.flagged.clear();
+                Ok(())
+            }
+            Navigate::Flagged if c == 'x' => status.menu.remove_selected_flagged(),
+            Navigate::Flagged if c == 'j' => status.jump_flagged(),
             _ => {
                 status.reset_edit_mode()?;
                 status.current_tab_mut().reset_display_mode_and_view()

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -14,9 +14,9 @@ use crate::io::{execute_without_output_with_path, read_log};
 use crate::log_info;
 use crate::log_line;
 use crate::modes::{
-    copy_move, help_string, lsblk_and_cryptsetup_installed, open_tui_program, Content,
-    ContentWindow, Display, Edit, InputCompleted, InputSimple, LeaveMode, MarkAction, Navigate,
-    NeedConfirmation, Preview, RemovableDevices, Search, Selectable,
+    help_string, lsblk_and_cryptsetup_installed, open_tui_program, Content, ContentWindow, Display,
+    Edit, InputCompleted, InputSimple, LeaveMode, MarkAction, Navigate, NeedConfirmation,
+    PreviewBuilder, RemovableDevices, Search, Selectable,
 };
 
 /// Links events from tuikit to custom actions.
@@ -564,7 +564,7 @@ impl EventAction {
         }
         let help = help_string(binds, &status.internal_settings.opener);
         status.current_tab_mut().set_display_mode(Display::Preview);
-        status.current_tab_mut().preview = Preview::help(&help);
+        status.current_tab_mut().preview = PreviewBuilder::help(&help);
         let len = status.current_tab().preview.len();
         status.current_tab_mut().window.reset(len);
         Ok(())
@@ -580,7 +580,7 @@ impl EventAction {
         };
         let tab = status.current_tab_mut();
         tab.set_display_mode(Display::Preview);
-        tab.preview = Preview::log(log);
+        tab.preview = PreviewBuilder::log(log);
         tab.window.reset(tab.preview.len());
         tab.preview_go_bottom();
         Ok(())

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -1541,19 +1541,11 @@ impl EventAction {
             "file copied - pool: {pool:?}",
             pool = status.internal_settings.copy_file_queue
         );
-        status.internal_settings.file_copied()?;
+        status.internal_settings.copy_file_remove_head()?;
         if status.internal_settings.copy_file_queue.is_empty() {
             status.internal_settings.unset_copy_progress()
         } else {
-            let (sources, dest) = status.internal_settings.copy_file_queue[0].clone();
-            let in_mem = copy_move(
-                crate::modes::CopyMove::Copy,
-                sources,
-                dest,
-                status.internal_settings.term.clone(),
-                std::sync::Arc::clone(&status.fm_sender),
-            )?;
-            status.internal_settings.store_copy_progress(in_mem);
+            status.copy_next_file_in_queue()?;
         }
         Ok(())
     }

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -14,9 +14,9 @@ use crate::io::{execute_without_output_with_path, read_log};
 use crate::log_info;
 use crate::log_line;
 use crate::modes::{
-    help_string, lsblk_and_cryptsetup_installed, open_tui_program, Content, ContentWindow, Display,
-    Edit, InputCompleted, InputSimple, LeaveMode, MarkAction, Navigate, NeedConfirmation,
-    PreviewBuilder, RemovableDevices, Search, Selectable,
+    help_string, lsblk_and_cryptsetup_installed, open_tui_program, ContentWindow, Display, Edit,
+    InputCompleted, InputSimple, LeaveMode, MarkAction, Navigate, NeedConfirmation, PreviewBuilder,
+    RemovableDevices, Search, Selectable,
 };
 
 /// Links events from tuikit to custom actions.
@@ -787,10 +787,6 @@ impl EventAction {
             .current_tab_mut()
             .cd(START_FOLDER.get().context("Start folder should be set")?)?;
         status.update_second_pane_for_preview()
-    }
-
-    fn jump_flagged(status: &mut Status) -> Result<()> {
-        status.jump_flagged()
     }
 
     pub fn search_next(status: &mut Status) -> Result<()> {

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -85,7 +85,7 @@ impl EventAction {
             if status.reset_edit_mode()? {
                 status.tabs[status.index].refresh_view()?;
             } else {
-                status.tabs[status.index].refresh_params()?;
+                status.tabs[status.index].refresh_params();
             }
         } else if matches!(
             status.current_tab().display_mode,
@@ -468,7 +468,7 @@ impl EventAction {
         let is_dir = path.is_dir();
         if is_dir {
             status.current_tab_mut().cd(&path)?;
-            status.current_tab_mut().make_tree(None)?;
+            status.current_tab_mut().make_tree(None);
             status.current_tab_mut().set_display_mode(Display::Tree);
             Ok(())
         } else {

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -929,7 +929,7 @@ impl EventAction {
         match tab.display_mode {
             Display::Directory => tab.normal_up_one_row(),
             Display::Preview => tab.preview_page_up(),
-            Display::Tree => tab.tree_select_prev()?,
+            Display::Tree => tab.tree_select_prev(),
             Display::Flagged => status.menu.flagged.select_prev(),
         }
         Ok(())
@@ -940,7 +940,7 @@ impl EventAction {
         match tab.display_mode {
             Display::Directory => tab.normal_down_one_row(),
             Display::Preview => tab.preview_page_down(),
-            Display::Tree => tab.tree_select_next()?,
+            Display::Tree => tab.tree_select_next(),
             Display::Flagged => status.menu.flagged.select_next(),
         }
         Ok(())
@@ -1113,7 +1113,7 @@ impl EventAction {
             match tab.display_mode {
                 Display::Directory => tab.normal_go_bottom(),
                 Display::Preview => tab.preview_go_bottom(),
-                Display::Tree => tab.tree_go_to_bottom_leaf()?,
+                Display::Tree => tab.tree_go_to_bottom_leaf(),
                 Display::Flagged => status.menu.flagged.select_last(),
             };
             status.update_second_pane_for_preview()?;

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -6,7 +6,7 @@ use indicatif::InMemoryTerm;
 
 use crate::app::{Focus, Status, Tab};
 use crate::common::{
-    filename_to_clipboard, filepath_to_clipboard, get_clipboard, is_program_in_path,
+    filename_to_clipboard, filepath_to_clipboard, get_clipboard, is_in_path,
     open_in_current_neovim, set_clipboard, tilde, CONFIG_PATH, GIO, LAZYGIT, NCDU,
 };
 use crate::config::{Bindings, START_FOLDER};
@@ -1333,7 +1333,7 @@ impl EventAction {
         ) {
             status.reset_edit_mode()?;
         } else {
-            if !is_program_in_path(GIO) {
+            if !is_in_path(GIO) {
                 log_line!("gio must be installed.");
                 return Ok(());
             }

--- a/src/event/event_exec.rs
+++ b/src/event/event_exec.rs
@@ -154,7 +154,7 @@ impl EventAction {
                 .menu
                 .flagged
                 .set_height(status.internal_settings.term.term_size()?.1);
-            status.set_edit_mode(status.index, Edit::Navigate(Navigate::Flagged));
+            status.set_edit_mode(status.index, Edit::Navigate(Navigate::Flagged))?;
         }
         Ok(())
     }
@@ -790,15 +790,7 @@ impl EventAction {
     }
 
     fn jump_flagged(status: &mut Status) -> Result<()> {
-        let Some(path) = status.menu.flagged.selected() else {
-            return Ok(());
-        };
-        let path = path.to_owned();
-        let tab = status.current_tab_mut();
-        tab.set_display_mode(Display::Directory);
-        tab.refresh_view()?;
-        tab.jump(path)?;
-        status.update_second_pane_for_preview()
+        status.jump_flagged()
     }
 
     pub fn search_next(status: &mut Status) -> Result<()> {

--- a/src/io/commands.rs
+++ b/src/io/commands.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::common::{current_username, is_program_in_path, SETSID};
+use crate::common::{current_username, is_in_path, SETSID};
 use crate::modes::PasswordHolder;
 use crate::{log_info, log_line};
 
@@ -24,7 +24,7 @@ where
 {
     log_info!("execute. executable: {exe:?}, arguments: {args:?}");
     log_line!("Execute: {exe:?}, arguments: {args:?}");
-    if is_program_in_path(SETSID) {
+    if is_in_path(SETSID) {
         Ok(Command::new(SETSID)
             .arg(exe)
             .args(args)
@@ -71,7 +71,7 @@ where
         "execute_in_child_without_output_with_path. executable: {exe:?}, arguments: {args:?}"
     );
     let params = args.unwrap_or(&[]);
-    if is_program_in_path(SETSID) {
+    if is_in_path(SETSID) {
         Ok(Command::new(SETSID)
             .arg(exe)
             .stdin(Stdio::null())
@@ -202,7 +202,7 @@ pub fn execute_with_ansi_colors(args: &[&str]) -> Result<std::process::Output> {
 pub fn execute_custom(exec_command: String, files: &[std::path::PathBuf]) -> Result<bool> {
     let mut args: Vec<&str> = exec_command.split(' ').collect();
     let command = args.remove(0);
-    if !std::path::Path::new(command).exists() && !is_program_in_path(command) {
+    if !std::path::Path::new(command).exists() && !is_in_path(command) {
         log_info!("{command} can't be found - args {exec_command:?}");
         return Ok(false);
     }

--- a/src/io/display.rs
+++ b/src/io/display.rs
@@ -863,12 +863,12 @@ impl<'a> WinSecondary<'a> {
     fn draw_history(&self, canvas: &mut dyn Canvas) -> Result<()> {
         let selectable = &self.tab.history;
         let content = selectable.content();
-        for (row, pair, attr) in enumerated_colored_iter!(content) {
+        for (row, path, attr) in enumerated_colored_iter!(content) {
             let attr = selectable.attr(row, &attr);
             Self::draw_content_line(
                 canvas,
                 row + 1,
-                pair.0.to_str().context("Unreadable filename")?,
+                path.to_str().context("Unreadable filename")?,
                 attr,
             )?;
         }

--- a/src/io/display.rs
+++ b/src/io/display.rs
@@ -36,7 +36,6 @@ use crate::modes::Selectable;
 use crate::modes::Trash;
 use crate::modes::TreeLineBuilder;
 use crate::modes::TreePreview;
-use crate::modes::Ueberzug;
 use crate::modes::Window;
 use crate::modes::{parse_input_mode, SecondLine};
 use crate::modes::{BinaryContent, Ueber};

--- a/src/io/display.rs
+++ b/src/io/display.rs
@@ -549,33 +549,6 @@ impl<'a> WinMain<'a> {
         )?;
         Ok(())
     }
-
-    fn draw_fagged(&self, canvas: &mut dyn Canvas) -> Result<Option<usize>> {
-        let window = &self.status.menu.flagged.window;
-        for (index, path) in self
-            .status
-            .menu
-            .flagged
-            .content
-            .iter()
-            .enumerate()
-            .skip(window.top)
-            .take(min(canvas.height()?, window.bottom + 0))
-        {
-            let fileinfo = FileInfo::new(path, &self.tab.users)?;
-            let mut attr = fileinfo.attr();
-            if index == self.status.menu.flagged.index {
-                attr.effect |= Effect::REVERSE;
-            }
-            let row = index + 2 - window.top;
-            canvas.print_with_attr(row, 0, &fileinfo.path.to_string_lossy(), attr)?;
-        }
-        if let Some(selected) = self.status.menu.flagged.selected() {
-            let fileinfo = FileInfo::new(selected, &self.tab.users)?;
-            canvas.print_with_attr(0, 1, &fileinfo.format(6, 6)?, fileinfo.attr())?;
-        };
-        Ok(None)
-    }
 }
 
 struct TreeLinePosition {

--- a/src/io/display.rs
+++ b/src/io/display.rs
@@ -18,7 +18,6 @@ use crate::config::{ColorG, Gradient, MENU_ATTRS};
 use crate::io::read_last_log_line;
 use crate::io::ModeFormat;
 use crate::log_info;
-use crate::modes::BinaryContent;
 use crate::modes::ColoredText;
 use crate::modes::Content;
 use crate::modes::ContentWindow;
@@ -40,6 +39,7 @@ use crate::modes::TreePreview;
 use crate::modes::Ueberzug;
 use crate::modes::Window;
 use crate::modes::{parse_input_mode, SecondLine};
+use crate::modes::{BinaryContent, Ueber};
 
 trait ClearLine {
     fn clear_line(&mut self, row: usize) -> Result<()>;
@@ -516,10 +516,10 @@ impl<'a> WinMain<'a> {
         Ok(())
     }
 
-    fn draw_ueberzug(&self, image: &Ueberzug, canvas: &mut dyn Canvas) -> Result<()> {
+    fn draw_ueberzug(&self, image: &Ueber, canvas: &mut dyn Canvas) -> Result<()> {
         let (width, height) = canvas.size()?;
-        image.match_index()?;
-        image.ueberzug(
+        // image.match_index()?;
+        image.draw(
             self.attributes.x_position as u16 + 2,
             3,
             width as u16 - 2,

--- a/src/io/display.rs
+++ b/src/io/display.rs
@@ -1242,7 +1242,7 @@ impl<'a> WinSecondary<'a> {
             .iter()
             .enumerate()
             .skip(window.top)
-            .take(min(canvas.height()?, window.bottom + 0))
+            .take(min(canvas.height()?, window.bottom))
         {
             let fileinfo = FileInfo::new(path, &self.tab.users)?;
             let mut attr = fileinfo.attr();
@@ -1250,11 +1250,11 @@ impl<'a> WinSecondary<'a> {
                 attr.effect |= Effect::REVERSE;
             }
             let row = index + 2 - window.top;
-            canvas.print_with_attr(row, 0, &fileinfo.path.to_string_lossy(), attr)?;
+            canvas.print_with_attr(row, 2, &fileinfo.path.to_string_lossy(), attr)?;
         }
         if let Some(selected) = self.status.menu.flagged.selected() {
             let fileinfo = FileInfo::new(selected, &self.tab.users)?;
-            canvas.print_with_attr(0, 1, &fileinfo.format(6, 6)?, fileinfo.attr())?;
+            canvas.print_with_attr(0, 2, &fileinfo.format(6, 6)?, fileinfo.attr())?;
         };
         Ok(())
     }

--- a/src/io/display.rs
+++ b/src/io/display.rs
@@ -440,28 +440,7 @@ impl<'a> WinMain<'a> {
             Preview::ColoredText(colored_text) => {
                 self.draw_colored_text(colored_text, length, canvas, window)?
             }
-            Preview::Archive(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
-            Preview::Media(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
             Preview::Text(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
-            Preview::Iso(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
-            Preview::Socket(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
-            Preview::BlockDevice(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
-            Preview::FifoCharDevice(text) => {
-                impl_preview!(text, tab, length, canvas, line_number_width, window, height)
-            }
-            Preview::Torrent(text) => {
                 impl_preview!(text, tab, length, canvas, line_number_width, window, height)
             }
 

--- a/src/io/git.rs
+++ b/src/io/git.rs
@@ -10,7 +10,6 @@ use std::path::Path;
 use anyhow::{anyhow, Context, Result};
 
 use crate::common::is_in_path;
-
 use crate::io::execute_and_output_no_log;
 
 #[derive(Default)]

--- a/src/io/git.rs
+++ b/src/io/git.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 
 use crate::io::execute_and_output_no_log;
 
@@ -137,7 +137,7 @@ fn porcelain2() -> Result<std::process::Output> {
 /// Returns a string representation of the git status of this path.
 /// Will return an empty string if we're not in a git repository.
 pub fn git(path: &Path) -> Result<String> {
-    if !is_program_in_path("git") {
+    if !is_in_path("git") {
         return Ok("".to_owned());
     }
     if std::env::set_current_dir(path).is_err() {

--- a/src/io/input_history.rs
+++ b/src/io/input_history.rs
@@ -6,12 +6,9 @@ use strum_macros::Display;
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::{
-    common::read_lines,
-    common::tilde,
-    io::Args,
-    modes::{Edit, InputCompleted, InputSimple},
-};
+use crate::common::{read_lines, tilde};
+use crate::io::Args;
+use crate::modes::{Edit, InputCompleted, InputSimple};
 
 pub struct InputHistory {
     file_path: std::path::PathBuf,

--- a/src/io/log.rs
+++ b/src/io/log.rs
@@ -4,8 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 use log4rs;
 
-use crate::common::extract_lines;
-use crate::common::{tilde, ACTION_LOG_PATH, LOG_CONFIG_PATH};
+use crate::common::{extract_lines, tilde, ACTION_LOG_PATH, LOG_CONFIG_PATH};
 use crate::io::Args;
 
 /// Holds the last action which is displayed to the user

--- a/src/io/opendal.rs
+++ b/src/io/opendal.rs
@@ -12,6 +12,7 @@ use serde_yml::to_string as to_yml_string;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
+use crate::common::path_to_config_folder;
 use crate::common::path_to_string;
 use crate::common::tilde;
 use crate::common::CONFIG_FOLDER;
@@ -124,6 +125,18 @@ impl OpendalKind {
             Self::GoogleDrive => "Google Drive",
         }
     }
+}
+
+pub fn get_cloud_token_names() -> Result<Vec<String>> {
+    Ok(std::fs::read_dir(path_to_config_folder()?)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_file())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|filename| filename.starts_with("token_"))
+        .filter(|filename| filename.ends_with(".yaml"))
+        .map(|filename| filename.replace("token_", ""))
+        .map(|filename| filename.replace(".yaml", ""))
+        .collect())
 }
 
 /// Formating used to display elements.

--- a/src/io/opendal.rs
+++ b/src/io/opendal.rs
@@ -12,16 +12,9 @@ use serde_yml::to_string as to_yml_string;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
-use crate::common::path_to_config_folder;
-use crate::common::path_to_string;
-use crate::common::tilde;
-use crate::common::CONFIG_FOLDER;
-use crate::impl_content;
-use crate::impl_selectable;
-use crate::log_info;
-use crate::log_line;
-use crate::modes::human_size;
-use crate::modes::FileInfo;
+use crate::common::{path_to_config_folder, path_to_string, tilde, CONFIG_FOLDER};
+use crate::modes::{human_size, FileInfo};
+use crate::{impl_content, impl_selectable, log_info, log_line};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GoogleDriveConfig {

--- a/src/io/opener.rs
+++ b/src/io/opener.rs
@@ -8,16 +8,13 @@ use serde_yml::Value;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::common::is_in_path;
-use crate::common::tilde;
 use crate::common::{
-    OPENER_AUDIO, OPENER_DEFAULT, OPENER_IMAGE, OPENER_OFFICE, OPENER_PATH, OPENER_READABLE,
-    OPENER_TEXT, OPENER_VECT, OPENER_VIDEO,
+    is_in_path, tilde, OPENER_AUDIO, OPENER_DEFAULT, OPENER_IMAGE, OPENER_OFFICE, OPENER_PATH,
+    OPENER_READABLE, OPENER_TEXT, OPENER_VECT, OPENER_VIDEO,
 };
 use crate::io::execute;
 use crate::log_info;
-use crate::modes::extract_extension;
-use crate::modes::{decompress_gz, decompress_xz, decompress_zip};
+use crate::modes::{decompress_gz, decompress_xz, decompress_zip, extract_extension};
 
 /// Different kind of extensions for default openers.
 #[derive(Clone, Hash, Eq, PartialEq, Debug, Display, Default, EnumString, EnumIter)]

--- a/src/io/opener.rs
+++ b/src/io/opener.rs
@@ -8,7 +8,7 @@ use serde_yml::Value;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 use crate::common::tilde;
 use crate::common::{
     OPENER_AUDIO, OPENER_DEFAULT, OPENER_IMAGE, OPENER_OFFICE, OPENER_PATH, OPENER_READABLE,
@@ -282,7 +282,7 @@ impl Kind {
     }
 
     fn is_valid(&self) -> bool {
-        !self.is_external() || is_program_in_path(self.external_program().unwrap_or_default().0)
+        !self.is_external() || is_in_path(self.external_program().unwrap_or_default().0)
     }
 
     fn external_program(&self) -> Result<(&str, bool)> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,5 @@
 /// When the user issues a quit event, the main loop is broken
 /// Then we reset the cursor, drop everything holding a terminal and print the last path.
 fn main() -> anyhow::Result<()> {
-    let mut fm = fm::app::FM::start()?;
-    fm.run()?;
-    let last_path = fm.quit()?;
-    fm::common::print_on_quit(last_path);
-    Ok(())
+    fm::app::FM::start()?.run()?.quit()
 }

--- a/src/modes/display/content_window.rs
+++ b/src/modes/display/content_window.rs
@@ -120,4 +120,21 @@ impl ContentWindow {
     pub fn is_row_in_header(row: u16) -> bool {
         row < Self::HEADER_ROWS as u16
     }
+
+    pub fn preview_page_up(&mut self) {
+        if self.top == 0 {
+            return;
+        }
+        let skip = min(self.top, 30);
+        self.bottom -= skip;
+        self.top -= skip;
+    }
+
+    pub fn preview_page_down(&mut self, preview_len: usize) {
+        if self.bottom < preview_len {
+            let skip = min(preview_len - self.bottom, 30);
+            self.bottom += skip;
+            self.top += skip;
+        }
+    }
 }

--- a/src/modes/display/directory.rs
+++ b/src/modes/display/directory.rs
@@ -203,6 +203,17 @@ impl Directory {
             .map(|fileinfo| fileinfo.path.borrow())
             .collect()
     }
+
+    /// True iff the selected path is ".." which is the parent dir.
+    pub fn is_dotdot_selected(&self) -> bool {
+        let Some(selected) = &self.selected() else {
+            return false;
+        };
+        let Some(parent) = self.path.parent() else {
+            return false;
+        };
+        selected.path.as_ref() == parent
+    }
 }
 
 impl_selectable!(Directory);

--- a/src/modes/display/directory.rs
+++ b/src/modes/display/directory.rs
@@ -129,8 +129,8 @@ impl Directory {
         match fileinfo.file_kind {
             FileKind::Directory => Ok(true),
             FileKind::SymbolicLink(true) => {
-                let dest = read_symlink_dest(&fileinfo.path).unwrap_or_default();
-                Ok(Path::new(&dest).is_dir())
+                let dest = std::fs::read_link(&fileinfo.path).unwrap_or_default();
+                Ok(dest.is_dir())
             }
             _ => Ok(false),
         }
@@ -196,17 +196,6 @@ impl Directory {
 
 impl_selectable!(Directory);
 impl_content!(FileInfo, Directory);
-
-/// Returns `Some(destination)` where `destination` is a String if the path is
-/// the destination of a symlink,
-/// Returns `None` if the link is broken, if the path doesn't exists or if the path
-/// isn't a symlink.
-pub fn read_symlink_dest(path: &Path) -> Option<String> {
-    match std::fs::read_link(path) {
-        Ok(dest) if dest.exists() => Some(dest.to_str()?.to_owned()),
-        _ => None,
-    }
-}
 
 fn get_used_space(files: &[FileInfo]) -> u64 {
     files

--- a/src/modes/display/directory.rs
+++ b/src/modes/display/directory.rs
@@ -125,20 +125,11 @@ impl Directory {
     /// Is the selected file a directory ?
     /// It may fails if the current path is empty, aka if nothing is selected.
     pub fn is_selected_dir(&self) -> Result<bool> {
-        match self
-            .selected()
-            .context("is selected dir: Empty directory")?
-            .file_kind
-        {
+        let fileinfo = self.selected().context("")?;
+        match fileinfo.file_kind {
             FileKind::Directory => Ok(true),
             FileKind::SymbolicLink(true) => {
-                let dest = read_symlink_dest(
-                    &self
-                        .selected()
-                        .context("is selected dir: unreachable")?
-                        .path,
-                )
-                .unwrap_or_default();
+                let dest = read_symlink_dest(&fileinfo.path).unwrap_or_default();
                 Ok(Path::new(&dest).is_dir())
             }
             _ => Ok(false),

--- a/src/modes/display/directory.rs
+++ b/src/modes/display/directory.rs
@@ -208,42 +208,6 @@ impl Directory {
 impl_selectable!(Directory);
 impl_content!(FileInfo, Directory);
 
-const MAX_PATH_ELEM_SIZE: usize = 50;
-
-/// Shorten a path to be displayed in 50 chars or less.
-/// Each element of the path is shortened if needed.
-pub fn shorten_path(path: &Path, size: Option<usize>) -> Result<String> {
-    if path == Path::new("/") {
-        return Ok("".to_owned());
-    }
-    let size = match size {
-        Some(size) => size,
-        None => MAX_PATH_ELEM_SIZE,
-    };
-    let path_string = path
-        .to_str()
-        .context("summarize: couldn't parse the path")?
-        .to_owned();
-
-    if path_string.len() < size {
-        return Ok(path_string);
-    }
-
-    let splitted_path: Vec<_> = path_string.split('/').collect();
-    let size_per_elem = std::cmp::max(1, size / (splitted_path.len() + 1)) + 1;
-    let shortened_elems: Vec<_> = splitted_path
-        .iter()
-        .filter_map(|p| {
-            if p.len() <= size_per_elem {
-                Some(*p)
-            } else {
-                p.get(0..size_per_elem)
-            }
-        })
-        .collect();
-    Ok(shortened_elems.join("/"))
-}
-
 /// Returns `Some(destination)` where `destination` is a String if the path is
 /// the destination of a symlink,
 /// Returns `None` if the link is broken, if the path doesn't exists or if the path

--- a/src/modes/display/fileinfo.rs
+++ b/src/modes/display/fileinfo.rs
@@ -143,7 +143,7 @@ impl SizeColumn {
         }
     }
 
-    fn trimed(&self) -> String {
+    pub fn trimed(&self) -> String {
         format!("{self}").trim().to_owned()
     }
 }
@@ -319,57 +319,6 @@ impl FileInfo {
             return "/ ".to_string();
         };
         format!("/{filename} ")
-    }
-
-    /// Returns informations about the file as a vector of string.
-    pub fn context_info(&self, opener: &crate::io::Opener) -> Vec<String> {
-        let mut lines = vec![];
-        lines.push(format!(
-            "Owner/Group: {owner} / {group}",
-            owner = self.owner,
-            group = self.group
-        ));
-        if let Ok(perms) = self.permissions() {
-            lines.push(format!(
-                "Permissions: {dir_symbol}{perms}",
-                dir_symbol = self.dir_symbol()
-            ));
-        }
-        lines.push(format!(
-            "{size_kind} {size}",
-            size_kind = self.file_kind.size_description(),
-            size = self.size_column.trimed()
-        ));
-        if let Ok(metadata) = std::fs::metadata(&self.path) {
-            if let Ok(created) = metadata.created() {
-                if let Ok(dt) = extract_datetime(created) {
-                    lines.push(format!("Created:     {dt}"))
-                }
-            }
-            if let Ok(accessed) = metadata.accessed() {
-                if let Ok(dt) = extract_datetime(accessed) {
-                    lines.push(format!("Accessed:    {dt}"))
-                }
-            }
-            if let Ok(modified) = metadata.modified() {
-                if let Ok(dt) = extract_datetime(modified) {
-                    lines.push(format!("Modified:    {dt}"))
-                }
-            }
-        }
-        if let Some(opener) = opener.kind(&self.path) {
-            lines.push(format!("Opener:      {opener}"));
-        };
-        if matches!(self.file_kind, FileKind::NormalFile) {
-            let extension = &self.extension.to_lowercase();
-            let ext_kind = crate::modes::ExtensionKind::matcher(extension);
-            lines.push(format!("Previewer:   {ext_kind}"));
-        } else {
-            let kind = self.file_kind.long_description();
-            lines.push(format!("Kind:        {kind}"));
-        }
-
-        lines
     }
 
     pub fn attr(&self) -> Attr {

--- a/src/modes/display/fileinfo.rs
+++ b/src/modes/display/fileinfo.rs
@@ -291,13 +291,27 @@ impl FileInfo {
         self.path.is_dir()
     }
 
+    /// True iff the parent of the file is root.
+    /// It's also true for the root folder itself.
+    fn is_root_or_parent_is_root(&self) -> bool {
+        match self.path.as_ref().parent() {
+            None => true,
+            Some(parent) => parent == path::Path::new("/"),
+        }
+    }
+
     /// Formated proper name.
     /// "/ " for `.`
     pub fn filename_without_dot_dotdot(&self) -> String {
+        let sep = if self.is_root_or_parent_is_root() {
+            ""
+        } else {
+            "/"
+        };
         match self.filename.as_ref() {
-            "." => "/ ".to_owned(),
+            "." => format!("{sep} "),
             ".." => self.filename_without_dotdot(),
-            _ => format!("/{name} ", name = self.filename),
+            _ => format!("{sep}{name} ", name = self.filename,),
         }
     }
 

--- a/src/modes/display/fileinfo.rs
+++ b/src/modes/display/fileinfo.rs
@@ -51,8 +51,7 @@ impl FileKind<Valid> {
         } else if meta.file_type().is_fifo() {
             Self::Fifo
         } else if meta.file_type().is_symlink() {
-            let valid = is_valid_symlink(filepath);
-            Self::SymbolicLink(valid)
+            Self::SymbolicLink(is_valid_symlink(filepath))
         } else {
             Self::NormalFile
         }

--- a/src/modes/display/fileinfo.rs
+++ b/src/modes/display/fileinfo.rs
@@ -12,7 +12,7 @@ use tuikit::prelude::Attr;
 use crate::common::PERMISSIONS_STR;
 use crate::config::{extension_color, FILE_ATTRS};
 use crate::io::color_to_attr;
-use crate::modes::{human_size, read_symlink_dest, ToPath, Users, MAX_MODE};
+use crate::modes::{human_size, ToPath, Users, MAX_MODE};
 
 type Valid = bool;
 
@@ -246,9 +246,11 @@ impl FileInfo {
 
     fn expand_symlink(&self, repr: &mut String) {
         if let FileKind::SymbolicLink(_) = self.file_kind {
-            match read_symlink_dest(&self.path) {
-                Some(dest) => repr.push_str(&format!(" -> {dest}")),
-                None => repr.push_str("  broken link"),
+            match std::fs::read_link(&self.path) {
+                Ok(dest) if dest.exists() => {
+                    repr.push_str(&format!(" -> {dest}", dest = dest.display()))
+                }
+                _ => repr.push_str("  broken link"),
             }
         }
     }

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -18,5 +18,5 @@ pub use preview::{
 };
 pub use skim::{print_ansi_str, Skimer};
 pub use tree::{ColoredString, Go, Node, To, Tree, TreeLineBuilder, TreeLines};
-pub use uber::*;
+pub use uber::{Ueber, UeberBuilder};
 pub use users::Users;

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -13,8 +13,7 @@ pub use fileinfo::{
     convert_octal_mode, extract_datetime, extract_extension, is_not_hidden, FileInfo, FileKind,
 };
 pub use preview::{
-    BinaryContent, ColoredText, ExtensionKind, HLContent, Preview, PreviewBuilder, Text, TextKind,
-    Window,
+    BinaryContent, ExtensionKind, HLContent, Preview, PreviewBuilder, Text, TextKind, Window,
 };
 pub use skim::{print_ansi_str, Skimer};
 pub use tree::{ColoredString, Go, Node, To, Tree, TreeLineBuilder, TreeLines};

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -8,7 +8,7 @@ mod uber;
 mod users;
 
 pub use content_window::ContentWindow;
-pub use directory::{files_collection, human_size, read_symlink_dest, Directory};
+pub use directory::{files_collection, human_size, Directory};
 pub use fileinfo::{
     convert_octal_mode, extract_datetime, extract_extension, is_not_hidden, FileInfo, FileKind,
 };

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -4,6 +4,7 @@ mod fileinfo;
 mod preview;
 mod skim;
 mod tree;
+mod uber;
 mod users;
 
 pub use content_window::ContentWindow;
@@ -17,4 +18,5 @@ pub use preview::{
 };
 pub use skim::{print_ansi_str, Skimer};
 pub use tree::{ColoredString, Go, Node, To, Tree, TreeLineBuilder, TreeLines};
+pub use uber::*;
 pub use users::Users;

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -7,7 +7,7 @@ mod tree;
 mod users;
 
 pub use content_window::ContentWindow;
-pub use directory::{files_collection, human_size, read_symlink_dest, shorten_path, Directory};
+pub use directory::{files_collection, human_size, read_symlink_dest, Directory};
 pub use fileinfo::{
     convert_octal_mode, extract_datetime, extract_extension, is_not_hidden, FileInfo, FileKind,
 };

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -13,8 +13,8 @@ pub use fileinfo::{
     convert_octal_mode, extract_datetime, extract_extension, is_not_hidden, FileInfo, FileKind,
 };
 pub use preview::{
-    BinaryContent, ColoredText, ExtensionKind, HLContent, Preview, TextKind, TreePreview, Ueberzug,
-    Window,
+    BinaryContent, ColoredText, ExtensionKind, HLContent, Preview, PreviewBuilder, TextKind,
+    TreePreview, Window,
 };
 pub use skim::{print_ansi_str, Skimer};
 pub use tree::{ColoredString, Go, Node, To, Tree, TreeLineBuilder, TreeLines};

--- a/src/modes/display/mod.rs
+++ b/src/modes/display/mod.rs
@@ -13,8 +13,8 @@ pub use fileinfo::{
     convert_octal_mode, extract_datetime, extract_extension, is_not_hidden, FileInfo, FileKind,
 };
 pub use preview::{
-    BinaryContent, ColoredText, ExtensionKind, HLContent, Preview, PreviewBuilder, TextKind,
-    TreePreview, Window,
+    BinaryContent, ColoredText, ExtensionKind, HLContent, Preview, PreviewBuilder, Text, TextKind,
+    Window,
 };
 pub use skim::{print_ansi_str, Skimer};
 pub use tree::{ColoredString, Go, Node, To, Tree, TreeLineBuilder, TreeLines};

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -111,21 +111,22 @@ impl ExtensionKind {
 }
 
 impl std::fmt::Display for ExtensionKind {
+    #[rustfmt::skip]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Archive => write!(f, "archive"),
-            Self::Image => write!(f, "image"),
-            Self::Audio => write!(f, "audio"),
-            Self::Video => write!(f, "video"),
-            Self::Font => write!(f, "font"),
-            Self::Svg => write!(f, "svg"),
-            Self::Pdf => write!(f, "pdf"),
-            Self::Iso => write!(f, "iso"),
-            Self::Notebook => write!(f, "notebook"),
-            Self::Office => write!(f, "office"),
-            Self::Epub => write!(f, "epub"),
-            Self::Torrent => write!(f, "torrent"),
-            Self::Default => write!(f, "default"),
+            Self::Archive   => write!(f, "archive"),
+            Self::Image     => write!(f, "image"),
+            Self::Audio     => write!(f, "audio"),
+            Self::Video     => write!(f, "video"),
+            Self::Font      => write!(f, "font"),
+            Self::Svg       => write!(f, "svg"),
+            Self::Pdf       => write!(f, "pdf"),
+            Self::Iso       => write!(f, "iso"),
+            Self::Notebook  => write!(f, "notebook"),
+            Self::Office    => write!(f, "office"),
+            Self::Epub      => write!(f, "epub"),
+            Self::Torrent   => write!(f, "torrent"),
+            Self::Default   => write!(f, "default"),
         }
     }
 }

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -35,6 +35,8 @@ use crate::modes::SortKind;
 use crate::modes::{list_files_tar, list_files_zip};
 use crate::modes::{TreeLineBuilder, TreeLines};
 
+use crate::modes::{Kind as UeberzugKind2, Ueber, UeberBuilder};
+
 /// Different kind of extension for grouped by previewers.
 /// Any extension we can preview should be matched here.
 #[derive(Default, Eq, PartialEq)]
@@ -124,7 +126,7 @@ pub enum Preview {
     Text(TextContent),
     Binary(BinaryContent),
     Archive(ArchiveContent),
-    Ueberzug(Ueberzug),
+    Ueberzug(Ueber),
     Media(MediaContent),
     Tree(TreePreview),
     Iso(Iso),
@@ -185,13 +187,12 @@ impl Preview {
                             && is_program_in_path(PDFINFO)
                             && is_program_in_path(PDFTOPPM)) =>
                     {
-                        Ok(Self::Ueberzug(Ueberzug::make(
-                            &file_info.path,
-                            UeberzugKind::Pdf,
-                        )?))
+                        Ok(Self::Ueberzug(
+                            UeberBuilder::new(&file_info.path, UeberzugKind2::Pdf).build()?,
+                        ))
                     }
                     ExtensionKind::Image if is_program_in_path(UEBERZUG) => Ok(Self::Ueberzug(
-                        Ueberzug::make(&file_info.path, UeberzugKind::Image)?,
+                        UeberBuilder::new(&file_info.path, UeberzugKind2::Image).build()?,
                     )),
                     ExtensionKind::Audio if is_program_in_path(MEDIAINFO) => {
                         Ok(Self::Media(MediaContent::new(&file_info.path)?))
@@ -199,26 +200,23 @@ impl Preview {
                     ExtensionKind::Video
                         if is_program_in_path(UEBERZUG) && is_program_in_path(FFMPEG) =>
                     {
-                        Ok(Self::Ueberzug(Ueberzug::make(
-                            &file_info.path,
-                            UeberzugKind::Video,
-                        )?))
+                        Ok(Self::Ueberzug(
+                            UeberBuilder::new(&file_info.path, UeberzugKind2::Video).build()?,
+                        ))
                     }
                     ExtensionKind::Font
                         if is_program_in_path(UEBERZUG) && is_program_in_path(FONTIMAGE) =>
                     {
-                        Ok(Self::Ueberzug(Ueberzug::make(
-                            &file_info.path,
-                            UeberzugKind::Font,
-                        )?))
+                        Ok(Self::Ueberzug(
+                            UeberBuilder::new(&file_info.path, UeberzugKind2::Font).build()?,
+                        ))
                     }
                     ExtensionKind::Svg
                         if is_program_in_path(UEBERZUG) && is_program_in_path(RSVG_CONVERT) =>
                     {
-                        Ok(Self::Ueberzug(Ueberzug::make(
-                            &file_info.path,
-                            UeberzugKind::Svg,
-                        )?))
+                        Ok(Self::Ueberzug(
+                            UeberBuilder::new(&file_info.path, UeberzugKind2::Svg).build()?,
+                        ))
                     }
                     ExtensionKind::Iso if is_program_in_path(ISOINFO) => {
                         Ok(Self::Iso(Iso::new(&file_info.path)?))
@@ -228,7 +226,7 @@ impl Preview {
                             .context("Preview: Couldn't parse notebook")?)
                     }
                     ExtensionKind::Office if is_program_in_path(LIBREOFFICE) => Ok(Self::Ueberzug(
-                        Ueberzug::make(&file_info.path, UeberzugKind::Office)?,
+                        UeberBuilder::new(&file_info.path, UeberzugKind2::Office).build()?,
                     )),
                     ExtensionKind::Epub if is_program_in_path(PANDOC) => {
                         Ok(Self::epub(&file_info.path).context("Preview: Couldn't parse epub")?)

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -275,13 +275,20 @@ impl<'a> PreviewBuilder<'a> {
             ExtensionKind::Audio if kind.has_programs() => {
                 Ok(Preview::Media(MediaContent::new(path)?))
             }
-            _ if kind.is_ueber_kind() && kind.has_programs() => Ok(Preview::Ueberzug(
-                UeberBuilder::new(path, kind.into()).build()?,
-            )),
+            _ if kind.is_ueber_kind() && kind.has_programs() => Self::ueber(path, kind),
             _ => match self.syntaxed(extension) {
                 Some(syntaxed_preview) => Ok(syntaxed_preview),
                 None => self.text_or_binary(),
             },
+        }
+    }
+
+    fn ueber(path: &Path, kind: ExtensionKind) -> Result<Preview> {
+        let preview = UeberBuilder::new(path, kind.into()).build()?;
+        if preview.is_empty() {
+            Ok(Preview::Empty)
+        } else {
+            Ok(Preview::Ueberzug(preview))
         }
     }
 

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -714,9 +714,6 @@ pub struct Line {
 }
 
 impl Line {
-    const ASCII_MIN_PRINTABLE: u8 = 31;
-    const ASCII_MAX_PRINTABLE: u8 = 126;
-
     fn new(line: Vec<u8>) -> Self {
         Self { line }
     }
@@ -734,20 +731,21 @@ impl Line {
         hex_repr
     }
 
+    /// Converts a byte into '.' if it represent a non ASCII printable char
+    /// or it's corresponding char.
+    fn byte_to_char(byte: &u8) -> char {
+        let ch = *byte as char;
+        if !ch.is_ascii_graphic() {
+            '.'
+        } else {
+            ch
+        }
+    }
+
     /// Format a line of 16 bytes as an ASCII string.
     /// Non ASCII printable bytes are replaced by dots.
     fn format_as_ascii(&self) -> String {
-        let mut line_of_char = String::new();
-        for byte in self.line.iter() {
-            if *byte < Self::ASCII_MIN_PRINTABLE || *byte > Self::ASCII_MAX_PRINTABLE {
-                line_of_char.push('.')
-            } else if let Some(c) = char::from_u32(*byte as u32) {
-                line_of_char.push(c);
-            } else {
-                line_of_char.push(' ')
-            }
-        }
-        line_of_char
+        self.line.iter().map(Self::byte_to_char).collect()
     }
 
     /// Print line of pair of bytes in hexadecimal, 16 bytes long.

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -7,7 +7,7 @@ use std::iter::{Enumerate, Skip, Take};
 use std::path::{Path, PathBuf};
 use std::slice::Iter;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use content_inspector::{inspect, ContentType};
 use syntect::{
     easy::HighlightLines,

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -24,8 +24,8 @@ use crate::common::{
 use crate::config::MONOKAI_THEME;
 use crate::io::execute_and_capture_output_without_check;
 use crate::modes::{
-    extract_extension, list_files_tar, list_files_zip, read_symlink_dest, ContentWindow, FileKind,
-    FilterKind, SortKind, Tree, TreeLineBuilder, TreeLines, Ueber, UeberBuilder, Users,
+    extract_extension, list_files_tar, list_files_zip, ContentWindow, FileKind, FilterKind,
+    SortKind, Tree, TreeLineBuilder, TreeLines, Ueber, UeberBuilder, Users,
 };
 
 /// Different kind of extension for grouped by previewers.
@@ -236,9 +236,11 @@ impl<'a> PreviewBuilder<'a> {
     }
 
     fn valid_symlink(&self) -> Result<Preview> {
-        let dest = read_symlink_dest(&self.path).context("broken symlink")?;
-        let dest_path = Path::new(&dest);
-        Self::new(dest_path, self.users).build()
+        Self::new(
+            &std::fs::read_link(&self.path).unwrap_or_default(),
+            self.users,
+        )
+        .build()
     }
 
     fn normal_file(&self) -> Result<Preview> {

--- a/src/modes/display/preview.rs
+++ b/src/modes/display/preview.rs
@@ -26,7 +26,7 @@ use crate::modes::FileKind;
 use crate::modes::Tree;
 use crate::modes::Users;
 
-use crate::common::{clear_tmp_file, filename_from_path, is_program_in_path, path_to_string};
+use crate::common::{clear_tmp_files, filename_from_path, is_program_in_path, path_to_string};
 use crate::io::{
     execute_and_capture_output, execute_and_capture_output_without_check, execute_and_output_no_log,
 };
@@ -144,7 +144,7 @@ impl Preview {
 
     /// Empty preview, holding nothing.
     pub fn empty() -> Self {
-        clear_tmp_file();
+        clear_tmp_files();
         Self::Empty
     }
 
@@ -169,7 +169,7 @@ impl Preview {
     /// Directories aren't handled there since we need more arguments to create
     /// their previews.
     pub fn file(file_info: &FileInfo) -> Result<Self> {
-        clear_tmp_file();
+        clear_tmp_files();
         match file_info.file_kind {
             FileKind::Directory => Err(anyhow!(
                 "{path} is a directory",

--- a/src/modes/display/skim.rs
+++ b/src/modes/display/skim.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use skim::prelude::*;
 use tuikit::term::Term;
 
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 use crate::common::{BAT_EXECUTABLE, CAT_EXECUTABLE, GREP_EXECUTABLE, RG_EXECUTABLE};
 
 /// Used to call skim, a clone of fzf.
@@ -107,7 +107,7 @@ fn pick_first_installed<'a>(commands: &'a [&'a str]) -> Option<&'a str> {
         let Some(program) = command.split_whitespace().next() else {
             continue;
         };
-        if is_program_in_path(program) {
+        if is_in_path(program) {
             return Some(command);
         }
     }

--- a/src/modes/display/skim.rs
+++ b/src/modes/display/skim.rs
@@ -2,8 +2,7 @@ use anyhow::{Context, Result};
 use skim::prelude::*;
 use tuikit::term::Term;
 
-use crate::common::is_in_path;
-use crate::common::{BAT_EXECUTABLE, CAT_EXECUTABLE, GREP_EXECUTABLE, RG_EXECUTABLE};
+use crate::common::{is_in_path, BAT_EXECUTABLE, CAT_EXECUTABLE, GREP_EXECUTABLE, RG_EXECUTABLE};
 
 /// Used to call skim, a clone of fzf.
 /// It's a simple wrapper around `Skim` which is used to simplify the interface.

--- a/src/modes/display/tree.rs
+++ b/src/modes/display/tree.rs
@@ -6,15 +6,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use tuikit::attr::Attr;
 
-use crate::common::filename_from_path;
-use crate::common::has_last_modification_happened_less_than;
-use crate::modes::files_collection;
-use crate::modes::FileInfo;
-use crate::modes::FilterKind;
-use crate::modes::Flagged;
-use crate::modes::SortKind;
-use crate::modes::ToPath;
-use crate::modes::Users;
+use crate::common::{filename_from_path, has_last_modification_happened_less_than};
+use crate::modes::{files_collection, FileInfo, FilterKind, Flagged, SortKind, ToPath, Users};
 
 /// Holds a string, its display attributes and the associated pathbuf.
 #[derive(Clone, Debug)]

--- a/src/modes/display/uber.rs
+++ b/src/modes/display/uber.rs
@@ -1,0 +1,303 @@
+use anyhow::{anyhow, Context, Result};
+
+use std::path::{Path, PathBuf};
+
+use crate::common::{
+    filename_from_path, path_to_string, CALC_PDF_PATH, FFMPEG, FONTIMAGE, LIBREOFFICE, PDFINFO,
+    PDFTOPPM, RSVG_CONVERT, THUMBNAIL_PATH_NO_EXT, THUMBNAIL_PATH_PNG, THUMBNAIL_PDF_PATH,
+};
+use crate::io::{
+    execute_and_capture_output, execute_and_capture_output_without_check, execute_and_output_no_log,
+};
+use crate::log_info;
+
+pub enum Kind {
+    Font,
+    Image,
+    Office,
+    Pdf,
+    Svg,
+    Video,
+}
+
+pub struct Ueber {
+    kind: Kind,
+    source: PathBuf,
+    identifier: String,
+    images: Vec<PathBuf>,
+    length: usize,
+    index: usize,
+    ueberzug: ueberzug::Ueberzug,
+}
+
+impl Ueber {
+    fn new(
+        kind: Kind,
+        source: PathBuf,
+        identifier: String,
+        images: Vec<PathBuf>,
+        length: usize,
+        index: usize,
+    ) -> Self {
+        let ueberzug = ueberzug::Ueberzug::new();
+        Self {
+            kind,
+            source,
+            identifier,
+            images,
+            length,
+            index,
+            ueberzug,
+        }
+    }
+    /// Only affect pdf thumbnail. Will decrease the index if possible.
+    pub fn up_one_row(&mut self) {
+        if let Kind::Pdf = self.kind {
+            if self.index > 0 {
+                self.index -= 1;
+            }
+        }
+    }
+
+    /// Only affect pdf thumbnail. Will increase the index if possible.
+    pub fn down_one_row(&mut self) {
+        if let Kind::Pdf = self.kind {
+            if self.index + 1 < self.len() {
+                self.index += 1;
+            }
+        }
+    }
+
+    /// 0 for every kind except pdf where it's the number of pages.
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Draw the image with ueberzug in the current window.
+    /// The position is absolute, which is problematic when the app is embeded into a floating terminal.
+    /// The whole struct instance is dropped when the preview is reset and the image is deleted.
+    pub fn draw(&self, x: u16, y: u16, width: u16, height: u16) {
+        self.ueberzug.draw(&ueberzug::UeConf {
+            identifier: &self.identifier,
+            path: &self.images[self.index].to_string_lossy(),
+            x,
+            y,
+            width: Some(width),
+            height: Some(height),
+            scaler: Some(ueberzug::Scalers::FitContain),
+            ..Default::default()
+        });
+    }
+}
+
+pub struct UeberBuilder {
+    kind: Kind,
+    source: PathBuf,
+}
+
+impl UeberBuilder {
+    // TODO! don't use static str but the str defined in constants
+    const VIDEO_THUMBNAILS: [&'static str; 6] = [
+        "/tmp/fm_thumbnail1.jpg",
+        "/tmp/fm_thumbnail2.jpg",
+        "/tmp/fm_thumbnail3.jpg",
+        "/tmp/fm_thumbnail4.jpg",
+        "/tmp/fm_thumbnail5.jpg",
+        "/tmp/fm_thumbnail6.jpg",
+    ];
+
+    pub fn new(source: PathBuf, kind: Kind) -> Self {
+        Self { source, kind }
+    }
+
+    pub fn build(self) -> Result<Ueber> {
+        match &self.kind {
+            Kind::Font => self.build_font(),
+            Kind::Image => self.build_image(),
+            Kind::Office => self.build_office(),
+            Kind::Pdf => self.build_pdf(),
+            Kind::Svg => self.build_svg(),
+            Kind::Video => self.build_video(),
+        }
+    }
+
+    fn build_office(self) -> Result<Ueber> {
+        let calc_str = path_to_string(&self.source);
+        let args = ["--convert-to", "pdf", "--outdir", "/tmp", &calc_str];
+        let output = execute_and_output_no_log(LIBREOFFICE, args)?;
+        if !output.stderr.is_empty() {
+            log_info!(
+                "libreoffice conversion output: {} {}",
+                String::from_utf8(output.stdout).unwrap_or_default(),
+                String::from_utf8(output.stderr).unwrap_or_default()
+            );
+            return Err(anyhow!("{LIBREOFFICE} couldn't convert {calc_str} to pdf"));
+        }
+        let mut pdf_path = std::path::PathBuf::from("/tmp");
+        let filename = self.source.file_name().context("")?;
+        pdf_path.push(filename);
+        pdf_path.set_extension("pdf");
+        std::fs::rename(pdf_path, CALC_PDF_PATH)?;
+        let calc_pdf_path = PathBuf::from(CALC_PDF_PATH);
+        let identifier = filename_from_path(&self.source)?.to_owned();
+        let length = Self::get_pdf_length(&calc_pdf_path)?;
+        Self::make_pdf_thumbnails(&calc_pdf_path)?;
+        let images = Self::make_pdf_images_paths(length)?;
+        Ok(Ueber::new(
+            Kind::Pdf,
+            self.source,
+            identifier,
+            images,
+            length,
+            0,
+        ))
+    }
+
+    fn make_pdf_thumbnails(path: &Path) -> Result<String> {
+        execute_and_capture_output_without_check(
+            PDFTOPPM,
+            &[
+                "-singlefile",
+                "-jpeg",
+                "-jpegopt",
+                "quality=75",
+                path.to_string_lossy().to_string().as_ref(),
+                THUMBNAIL_PDF_PATH,
+            ],
+        )
+    }
+
+    fn make_pdf_images_paths(length: usize) -> Result<Vec<PathBuf>> {
+        let images = (1..length)
+            .map(|index| PathBuf::from(format!("{THUMBNAIL_PDF_PATH}{index}.jpg")))
+            .collect();
+        Ok(images)
+    }
+
+    fn get_pdf_length(path: &Path) -> Result<usize> {
+        let output =
+            execute_and_capture_output(PDFINFO, &[path.to_string_lossy().to_string().as_ref()])?;
+        let line = output.lines().find(|line| line.starts_with("Pages: "));
+
+        match line {
+            Some(line) => {
+                let page_count_str = line.split_whitespace().nth(1).unwrap();
+                let page_count = page_count_str.parse::<usize>()?;
+                Ok(page_count)
+            }
+            None => Err(anyhow::Error::msg("Couldn't find the page number")),
+        }
+    }
+
+    fn build_pdf(self) -> Result<Ueber> {
+        let length = Self::get_pdf_length(&self.source)?;
+        let identifier = filename_from_path(&self.source)?.to_owned();
+        Self::make_pdf_thumbnails(&self.source)?;
+        let images = Self::make_pdf_images_paths(length)?;
+        Ok(Ueber::new(
+            Kind::Pdf,
+            self.source,
+            identifier,
+            images,
+            length,
+            0,
+        ))
+    }
+
+    fn build_video(self) -> Result<Ueber> {
+        let path_str = self
+            .source
+            .to_str()
+            .context("make_thumbnail: couldn't parse the path into a string")?;
+        Self::create_thumbnail(
+            FFMPEG,
+            &[
+                "-i",
+                path_str,
+                "-vf",
+                "\"select='not(mod(n\\,floor(t/6)))',scale=320:-1\"",
+                "thumbnail",
+                "-vsync",
+                "vfr",
+                "-frames:v",
+                "6",
+                "1",
+                &format!("{THUMBNAIL_PATH_NO_EXT}%d.jpg"),
+                "-y",
+            ],
+        )?;
+        let images = Self::VIDEO_THUMBNAILS
+            .map(PathBuf::from)
+            .into_iter()
+            .collect();
+        let identifier = filename_from_path(&self.source)?.to_owned();
+        let length = 6;
+        let index = 0;
+        Ok(Ueber::new(
+            self.kind,
+            self.source,
+            identifier,
+            images,
+            length,
+            index,
+        ))
+    }
+
+    fn build_single_image(self, images: Vec<PathBuf>) -> Result<Ueber> {
+        let identifier = filename_from_path(&self.source)?.to_owned();
+        let length = 1;
+        let index = 0;
+        Ok(Ueber::new(
+            self.kind,
+            self.source,
+            identifier,
+            images,
+            length,
+            index,
+        ))
+    }
+
+    fn build_font(self) -> Result<Ueber> {
+        let path_str = self
+            .source
+            .to_str()
+            .context("make_thumbnail: couldn't parse the path into a string")?;
+        Self::create_thumbnail(FONTIMAGE, &["-o", THUMBNAIL_PATH_PNG, path_str])?;
+        let images = vec![PathBuf::from(THUMBNAIL_PATH_PNG)];
+        self.build_single_image(images)
+    }
+
+    fn build_image(self) -> Result<Ueber> {
+        let images = vec![self.source.clone()];
+        self.build_single_image(images)
+    }
+
+    fn build_svg(self) -> Result<Ueber> {
+        let path_str = self
+            .source
+            .to_str()
+            .context("make_thumbnail: couldn't parse the path into a string")?;
+        Self::create_thumbnail(
+            RSVG_CONVERT,
+            &["--keep-aspect-ratio", path_str, "-o", THUMBNAIL_PATH_PNG],
+        )?;
+        let images = vec![PathBuf::from(THUMBNAIL_PATH_PNG)];
+        self.build_single_image(images)
+    }
+
+    fn create_thumbnail(exe: &str, args: &[&str]) -> Result<()> {
+        let output = execute_and_output_no_log(exe, args.to_owned())?;
+        if !output.stderr.is_empty() {
+            log_info!(
+                "make thumbnail output: {} {}",
+                String::from_utf8(output.stdout).unwrap_or_default(),
+                String::from_utf8(output.stderr).unwrap_or_default()
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/modes/display/uber.rs
+++ b/src/modes/display/uber.rs
@@ -153,12 +153,12 @@ impl UeberBuilder {
         let filename = self.source.file_name().context("")?;
         pdf_path.push(filename);
         pdf_path.set_extension("pdf");
-        std::fs::rename(&pdf_path, CALC_PDF_PATH)?;
-        let calc_pdf_path = PathBuf::from(CALC_PDF_PATH);
+        let calc_pdf_path = PathBuf::from(&pdf_path);
         let identifier = filename_from_path(&pdf_path)?.to_owned();
         let length = Self::get_pdf_length(&calc_pdf_path)?;
         Self::make_pdf_thumbnails(&calc_pdf_path)?;
         let images = Self::make_pdf_images_paths(length)?;
+        std::fs::remove_file(&pdf_path)?;
         log_info!("build_office: build complete!");
         Ok(Ueber::new(
             Kind::Pdf,

--- a/src/modes/edit/bulkrename.rs
+++ b/src/modes/edit/bulkrename.rs
@@ -6,11 +6,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, SystemTime};
 
-use crate::common::TMP_FOLDER_PATH;
-use crate::common::{random_name, rename};
+use crate::common::{random_name, rename, TMP_FOLDER_PATH};
 use crate::event::FmEvents;
-use crate::log_info;
-use crate::log_line;
+use crate::{log_info, log_line};
 
 struct BulkExecutor {
     original_filepath: Vec<PathBuf>,

--- a/src/modes/edit/cli_menu.rs
+++ b/src/modes/edit/cli_menu.rs
@@ -4,14 +4,10 @@ use serde_yml::from_reader;
 use serde_yml::Mapping;
 
 use crate::app::Status;
-use crate::common::is_in_path;
-use crate::common::tilde;
-use crate::impl_content;
-use crate::impl_selectable;
+use crate::common::{is_in_path, tilde};
 use crate::io::execute_with_ansi_colors;
-use crate::log_info;
-use crate::log_line;
 use crate::modes::ShellCommandParser;
+use crate::{impl_content, impl_selectable, log_info, log_line};
 
 pub trait Execute<T> {
     fn execute(&self, status: &Status) -> Result<T>;

--- a/src/modes/edit/cli_menu.rs
+++ b/src/modes/edit/cli_menu.rs
@@ -4,7 +4,7 @@ use serde_yml::from_reader;
 use serde_yml::Mapping;
 
 use crate::app::Status;
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 use crate::common::tilde;
 use crate::impl_content;
 use crate::impl_selectable;
@@ -41,7 +41,7 @@ pub struct CliCommand {
 impl CliCommand {
     fn new(desc: String, args: String) -> Option<Self> {
         let executable = args.split(' ').next()?;
-        if !is_program_in_path(executable) {
+        if !is_in_path(executable) {
             return None;
         }
         let desc = desc.replace('_', " ");

--- a/src/modes/edit/completion.rs
+++ b/src/modes/edit/completion.rs
@@ -4,7 +4,7 @@ use std::fs::{self, ReadDir};
 use anyhow::Result;
 use strum::IntoEnumIterator;
 
-use crate::common::{is_program_in_path, tilde, ZOXIDE};
+use crate::common::{is_in_path, tilde, ZOXIDE};
 use crate::event::ActionMap;
 use crate::io::execute_and_capture_output_with_path;
 use crate::modes::Leave;
@@ -158,7 +158,7 @@ impl Completion {
     }
 
     fn cd_update_from_zoxide(&mut self, input_string: &str, current_path: &str) {
-        if !is_program_in_path(ZOXIDE) {
+        if !is_in_path(ZOXIDE) {
             return;
         }
         let mut args = vec!["query"];

--- a/src/modes/edit/compress.rs
+++ b/src/modes/edit/compress.rs
@@ -8,9 +8,7 @@ use flate2::Compression;
 use lzma::LzmaWriter;
 use zip::write::SimpleFileOptions;
 
-use crate::impl_content;
-use crate::impl_selectable;
-use crate::log_line;
+use crate::{impl_content, impl_selectable, log_line};
 
 /// Different kind of compression methods
 #[derive(Debug)]

--- a/src/modes/edit/context.rs
+++ b/src/modes/edit/context.rs
@@ -1,6 +1,7 @@
 use crate::event::ActionMap;
-use crate::impl_content;
-use crate::impl_selectable;
+use crate::io::Opener;
+use crate::modes::{extract_datetime, ExtensionKind, FileInfo, FileKind};
+use crate::{impl_content, impl_selectable};
 
 const CONTEXT: [(&str, ActionMap); 10] = [
     ("Open", ActionMap::OpenFile),
@@ -45,3 +46,90 @@ type StaticStr = &'static str;
 
 impl_selectable!(ContextMenu);
 impl_content!(StaticStr, ContextMenu);
+
+/// Used to generate more informations about a file in the context menu.
+pub struct MoreInfos<'a> {
+    file_info: &'a FileInfo,
+    opener: &'a Opener,
+}
+
+impl<'a> MoreInfos<'a> {
+    pub fn new(file_info: &'a FileInfo, opener: &'a Opener) -> Self {
+        Self { file_info, opener }
+    }
+
+    /// Informations about the file as a vector of string.
+    pub fn to_lines(&self) -> Vec<String> {
+        let mut lines = vec![];
+
+        self.owner_group(&mut lines);
+        self.perms(&mut lines);
+        self.size(&mut lines);
+        self.times(&mut lines);
+        self.opener(&mut lines);
+        self.kind(&mut lines);
+
+        lines
+    }
+
+    fn owner_group(&self, lines: &mut Vec<String>) {
+        lines.push(format!(
+            "Owner/Group: {owner} / {group}",
+            owner = self.file_info.owner,
+            group = self.file_info.group
+        ));
+    }
+
+    fn perms(&self, lines: &mut Vec<String>) {
+        if let Ok(perms) = self.file_info.permissions() {
+            lines.push(format!(
+                "Permissions: {dir_symbol}{perms}",
+                dir_symbol = self.file_info.dir_symbol()
+            ));
+        }
+    }
+
+    fn size(&self, lines: &mut Vec<String>) {
+        lines.push(format!(
+            "{size_kind} {size}",
+            size_kind = self.file_info.file_kind.size_description(),
+            size = self.file_info.size_column.trimed()
+        ));
+    }
+
+    fn times(&self, lines: &mut Vec<String>) {
+        if let Ok(metadata) = std::fs::metadata(&self.file_info.path) {
+            if let Ok(created) = metadata.created() {
+                if let Ok(dt) = extract_datetime(created) {
+                    lines.push(format!("Created:     {dt}"))
+                }
+            }
+            if let Ok(accessed) = metadata.accessed() {
+                if let Ok(dt) = extract_datetime(accessed) {
+                    lines.push(format!("Accessed:    {dt}"))
+                }
+            }
+            if let Ok(modified) = metadata.modified() {
+                if let Ok(dt) = extract_datetime(modified) {
+                    lines.push(format!("Modified:    {dt}"))
+                }
+            }
+        }
+    }
+
+    fn opener(&self, lines: &mut Vec<String>) {
+        if let Some(opener) = self.opener.kind(&self.file_info.path) {
+            lines.push(format!("Opener:      {opener}"));
+        };
+    }
+
+    fn kind(&self, lines: &mut Vec<String>) {
+        if matches!(self.file_info.file_kind, FileKind::NormalFile) {
+            let ext_kind = ExtensionKind::matcher(&self.file_info.extension.to_lowercase());
+            lines.push(format!("Previewer:   {ext_kind}"));
+        } else {
+            let kind = self.file_info.file_kind.long_description();
+            lines.push(format!("Kind:        {kind}"));
+        }
+    }
+}

--- a/src/modes/edit/copy_move.rs
+++ b/src/modes/edit/copy_move.rs
@@ -9,8 +9,7 @@ use fs_extra;
 use indicatif::{InMemoryTerm, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
 use tuikit::prelude::Term;
 
-use crate::common::NOTIFY_EXECUTABLE;
-use crate::common::{is_in_path, random_name};
+use crate::common::{is_in_path, random_name, NOTIFY_EXECUTABLE};
 use crate::event::FmEvents;
 use crate::io::execute;
 use crate::modes::human_size;

--- a/src/modes/edit/copy_move.rs
+++ b/src/modes/edit/copy_move.rs
@@ -10,7 +10,7 @@ use indicatif::{InMemoryTerm, ProgressBar, ProgressDrawTarget, ProgressState, Pr
 use tuikit::prelude::Term;
 
 use crate::common::NOTIFY_EXECUTABLE;
-use crate::common::{is_program_in_path, random_name};
+use crate::common::{is_in_path, random_name};
 use crate::event::FmEvents;
 use crate::io::execute;
 use crate::modes::human_size;
@@ -307,7 +307,7 @@ impl Drop for ConflictHandler {
 /// Send a notification to the desktop.
 /// Does nothing if "notify-send" isn't installed.
 fn notify(text: &str) -> Result<()> {
-    if is_program_in_path(NOTIFY_EXECUTABLE) {
+    if is_in_path(NOTIFY_EXECUTABLE) {
         execute(NOTIFY_EXECUTABLE, &[text])?;
     }
     Ok(())

--- a/src/modes/edit/cryptsetup.rs
+++ b/src/modes/edit/cryptsetup.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use sysinfo::Disks;
 
-use crate::common::{current_username, is_program_in_path, MKDIR};
+use crate::common::{current_username, is_in_path, MKDIR};
 use crate::common::{CRYPTSETUP, LSBLK};
 use crate::impl_content;
 use crate::impl_selectable;
@@ -35,7 +35,7 @@ fn get_devices() -> Result<String> {
 /// True iff `lsblk` and `cryptsetup` are in path.
 /// Nothing here can be done without those programs.
 pub fn lsblk_and_cryptsetup_installed() -> bool {
-    is_program_in_path(LSBLK) && is_program_in_path(CRYPTSETUP)
+    is_in_path(LSBLK) && is_in_path(CRYPTSETUP)
 }
 
 /// Represent an encrypted device.

--- a/src/modes/edit/cryptsetup.rs
+++ b/src/modes/edit/cryptsetup.rs
@@ -1,18 +1,13 @@
 use anyhow::{anyhow, Context, Result};
 use sysinfo::Disks;
 
-use crate::common::{current_username, is_in_path, MKDIR};
-use crate::common::{CRYPTSETUP, LSBLK};
-use crate::impl_content;
-use crate::impl_selectable;
-use crate::io::execute_and_output;
+use crate::common::{current_username, is_in_path, CRYPTSETUP, LSBLK, MKDIR};
 use crate::io::{
-    drop_sudo_privileges, execute_sudo_command, execute_sudo_command_with_password,
-    reset_sudo_faillock, set_sudo_session,
+    drop_sudo_privileges, execute_and_output, execute_sudo_command,
+    execute_sudo_command_with_password, reset_sudo_faillock, set_sudo_session,
 };
-use crate::log_info;
-use crate::modes::{MountCommands, MountParameters, MountRepr};
-use crate::modes::{PasswordHolder, PasswordKind};
+use crate::modes::{MountCommands, MountParameters, MountRepr, PasswordHolder, PasswordKind};
+use crate::{impl_content, impl_selectable, log_info};
 
 /// Possible actions on encrypted drives
 #[derive(Debug, Clone, Copy)]

--- a/src/modes/edit/decompress.rs
+++ b/src/modes/edit/decompress.rs
@@ -1,7 +1,7 @@
+use std::{fs::File, path::Path};
+
 use anyhow::{Context, Result};
 use flate2::read::{GzDecoder, ZlibDecoder};
-use std::fs::File;
-use std::path::Path;
 use tar::Archive;
 
 use crate::common::{path_to_string, BSDTAR};

--- a/src/modes/edit/flagged.rs
+++ b/src/modes/edit/flagged.rs
@@ -2,10 +2,8 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::common::tilde;
-use crate::impl_content;
-use crate::impl_selectable;
-use crate::modes::ContentWindow;
-use crate::modes::ToPath;
+use crate::modes::{ContentWindow, ToPath};
+use crate::{impl_content, impl_selectable};
 
 #[derive(Clone, Debug)]
 pub struct Flagged {

--- a/src/modes/edit/flagged.rs
+++ b/src/modes/edit/flagged.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
+use crate::common::tilde;
 use crate::impl_content;
 use crate::impl_selectable;
 use crate::modes::ContentWindow;
@@ -194,6 +195,25 @@ impl Flagged {
             .filter(|p| p.starts_with(dir))
             .map(|p| p.to_owned())
             .collect()
+    }
+
+    /// Returns a string with every path in content on a separate line.
+    pub fn content_to_string(&self) -> String {
+        self.content()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
+
+    pub fn replace_by_string(&mut self, files: String) {
+        self.clear();
+        files.lines().for_each(|f| {
+            let p = std::path::PathBuf::from(tilde(f).as_ref());
+            if p.exists() {
+                self.push(p);
+            }
+        });
     }
 }
 

--- a/src/modes/edit/help.rs
+++ b/src/modes/edit/help.rs
@@ -143,7 +143,7 @@ Different modes for the bottom window
         ),
         trash_actions = action_descriptions!(TrashOpen, TrashEmpty),
         tree_actions = action_descriptions!(Tree, TreeFold, TreeFoldAll, TreeUnFoldAll),
-        display_modes = action_descriptions!(ResetMode, Tree, DisplayFlagged, Preview),
+        display_modes = action_descriptions!(ResetMode, Tree, Preview),
         edit_modes = action_descriptions!(
             Chmod,
             Exec,
@@ -164,6 +164,7 @@ Different modes for the bottom window
             CliMenu,
             RemoteMount,
             Filter,
+            DisplayFlagged,
             Context,
             Enter
         ),

--- a/src/modes/edit/history.rs
+++ b/src/modes/edit/history.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::impl_content;
-use crate::impl_selectable;
+use crate::{impl_content, impl_selectable};
 
 /// A stack of visited paths.
 /// We save the last folder and the selected file every time a `PatchContent` is updated.

--- a/src/modes/edit/history.rs
+++ b/src/modes/edit/history.rs
@@ -3,26 +3,24 @@ use std::path::{Path, PathBuf};
 use crate::impl_content;
 use crate::impl_selectable;
 
-type DoublePB = (PathBuf, PathBuf);
-
 /// A stack of visited paths.
 /// We save the last folder and the selected file every time a `PatchContent` is updated.
 /// We also ensure not to save the same pair multiple times.
 #[derive(Default, Clone)]
 pub struct History {
-    pub content: Vec<DoublePB>,
+    pub content: Vec<PathBuf>,
     pub index: usize,
 }
 
 impl History {
     /// Add a new path and a selected file in the stack, without duplicates, and select the last
     /// one.
-    pub fn push(&mut self, path: &Path, file: &Path) {
-        let pair = (path.to_owned(), file.to_owned());
-        if !self.content.contains(&pair) {
-            self.content.push(pair);
+    pub fn push(&mut self, file: &Path) {
+        if !self.content.contains(&file.to_path_buf()) {
+            self.content.push(file.to_owned());
             self.index = self.len() - 1;
         }
+        // TODO! Else ... ?
     }
 
     /// Drop the last visited paths from the stack, after the selected one.
@@ -49,9 +47,9 @@ impl History {
         if self.is_empty() {
             return false;
         }
-        self.content[self.len() - 1].0 == path
+        self.content[self.len() - 1] == path
     }
 }
 
 impl_selectable!(History);
-impl_content!(DoublePB, History);
+impl_content!(PathBuf, History);

--- a/src/modes/edit/leave_mode.rs
+++ b/src/modes/edit/leave_mode.rs
@@ -79,6 +79,7 @@ impl LeaveMode {
                 LeaveMode::picker(status)?;
                 return Ok(());
             }
+            Edit::Navigate(Navigate::Flagged) => LeaveMode::flagged(status),
             Edit::InputCompleted(InputCompleted::Exec) => LeaveMode::exec(status),
             Edit::InputCompleted(InputCompleted::Search) => LeaveMode::search(status, true),
             Edit::InputCompleted(InputCompleted::Cd) => LeaveMode::cd(status),
@@ -203,21 +204,13 @@ impl LeaveMode {
     fn rename(status: &mut Status) -> Result<()> {
         let old_path = status.current_tab().current_file()?.path;
         let new_name = status.menu.input.string();
-        let new_path = match rename(&old_path, &new_name) {
-            Ok(new_path) => new_path,
-            Err(error) => {
-                log_info!(
-                    "Error renaming {old_path} to {new_name}. Error: {error}",
-                    old_path = old_path.display()
-                );
-                return Err(error);
-            }
+        if let Err(error) = rename(&old_path, &new_name) {
+            log_info!(
+                "Error renaming {old_path} to {new_name}. Error: {error}",
+                old_path = old_path.display()
+            );
+            return Err(error);
         };
-        if matches!(status.current_tab().display_mode, Display::Flagged)
-            && status.menu.flagged.contains(&old_path)
-        {
-            status.menu.flagged.replace(&old_path, &new_path);
-        }
         status.current_tab_mut().refresh_view()
     }
 
@@ -446,5 +439,8 @@ impl LeaveMode {
             PickerCaller::Cloud => status.cloud_load_config(),
             PickerCaller::Unknown => Ok(()),
         }
+    }
+    fn flagged(status: &mut Status) -> Result<()> {
+        todo!();
     }
 }

--- a/src/modes/edit/leave_mode.rs
+++ b/src/modes/edit/leave_mode.rs
@@ -332,14 +332,12 @@ impl LeaveMode {
     /// Move back to a previously visited path.
     /// It may fail if the user has no permission to visit the path
     fn history(status: &mut Status) -> Result<()> {
-        let Some((path, file)) = status.current_tab().history.selected() else {
+        let Some(file) = status.tabs[status.index].history.selected() else {
             return Ok(());
         };
-        let (path, file) = (path.to_owned(), file.to_owned());
-        let tab = status.current_tab_mut();
-        tab.history.drop_queue();
-        tab.cd(&path)?;
-        tab.go_to_file(file);
+        let file = file.to_owned();
+        status.tabs[status.index].cd_to_file(&file)?;
+        status.tabs[status.index].history.drop_queue();
         status.update_second_pane_for_preview()
     }
 

--- a/src/modes/edit/leave_mode.rs
+++ b/src/modes/edit/leave_mode.rs
@@ -4,30 +4,15 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context, Result};
 
 use crate::app::Status;
-use crate::common::path_to_string;
-use crate::common::rename;
-use crate::common::string_to_path;
+use crate::common::{path_to_string, rename, string_to_path};
 use crate::config::Bindings;
-use crate::event::ActionMap;
-use crate::event::EventAction;
+use crate::event::{ActionMap, EventAction};
 use crate::io::execute_custom;
-use crate::log_info;
-use crate::log_line;
-use crate::modes::BlockDeviceAction;
-use crate::modes::CLApplications;
-use crate::modes::Content;
-use crate::modes::Display;
-use crate::modes::Edit;
-use crate::modes::InputCompleted;
-use crate::modes::InputSimple;
-use crate::modes::Leave;
-use crate::modes::MarkAction;
-use crate::modes::Navigate;
-use crate::modes::NodeCreation;
-use crate::modes::PasswordUsage;
-use crate::modes::PickerCaller;
-use crate::modes::Search;
-use crate::modes::SortKind;
+use crate::modes::{
+    BlockDeviceAction, CLApplications, Content, Display, Edit, InputCompleted, InputSimple, Leave,
+    MarkAction, Navigate, NodeCreation, PasswordUsage, PickerCaller, Search, SortKind,
+};
+use crate::{log_info, log_line};
 
 /// Methods called when executing something with Enter key.
 pub struct LeaveMode;

--- a/src/modes/edit/leave_mode.rs
+++ b/src/modes/edit/leave_mode.rs
@@ -305,7 +305,7 @@ impl LeaveMode {
         let completed = status.menu.completion.current_proposition();
         let path = string_to_path(completed)?;
         status.menu.input.reset();
-        status.current_tab_mut().cd(&path)?;
+        status.current_tab_mut().cd_to_file(&path)?;
         let len = status.current_tab().directory.content.len();
         status.current_tab_mut().window.reset(len);
         status.update_second_pane_for_preview()

--- a/src/modes/edit/leave_mode.rs
+++ b/src/modes/edit/leave_mode.rs
@@ -440,7 +440,8 @@ impl LeaveMode {
             PickerCaller::Unknown => Ok(()),
         }
     }
+
     fn flagged(status: &mut Status) -> Result<()> {
-        todo!();
+        status.jump_flagged()
     }
 }

--- a/src/modes/edit/marks.rs
+++ b/src/modes/edit/marks.rs
@@ -4,12 +4,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::common::read_lines;
-use crate::common::tilde;
-use crate::impl_content;
-use crate::impl_selectable;
-use crate::log_info;
-use crate::log_line;
+use crate::common::{read_lines, tilde};
+use crate::{impl_content, impl_selectable, log_info, log_line};
 
 /// Holds the marks created by the user.
 /// It's an ordered map between any char (except :) and a `PathBuf`.

--- a/src/modes/edit/menu.rs
+++ b/src/modes/edit/menu.rs
@@ -5,47 +5,22 @@ use anyhow::Context;
 use anyhow::Result;
 
 use crate::app::Tab;
-use crate::common::index_from_a;
-use crate::common::is_in_path;
-use crate::common::CLI_PATH;
-use crate::common::INPUT_HISTORY_PATH;
-use crate::common::MARKS_FILEPATH;
-use crate::common::SSHFS_EXECUTABLE;
-use crate::common::TUIS_PATH;
+use crate::common::{
+    index_from_a, is_in_path, CLI_PATH, INPUT_HISTORY_PATH, MARKS_FILEPATH, SSHFS_EXECUTABLE,
+    TUIS_PATH,
+};
 use crate::config::Bindings;
 use crate::event::FmEvents;
-use crate::io::drop_sudo_privileges;
-use crate::io::execute_and_capture_output_with_path;
-use crate::io::InputHistory;
-use crate::io::OpendalContainer;
-use crate::log_info;
-use crate::log_line;
-use crate::modes::Bulk;
-use crate::modes::CLApplications;
-use crate::modes::CliApplications;
-use crate::modes::Completion;
-use crate::modes::Compresser;
-use crate::modes::Content;
-use crate::modes::ContentWindow;
-use crate::modes::ContextMenu;
-use crate::modes::CryptoDeviceOpener;
-use crate::modes::Display;
-use crate::modes::Edit;
-use crate::modes::Flagged;
-use crate::modes::History;
-use crate::modes::Input;
-use crate::modes::InputCompleted;
-use crate::modes::IsoDevice;
-use crate::modes::Marks;
-use crate::modes::MountCommands;
-use crate::modes::Navigate;
-use crate::modes::PasswordHolder;
-use crate::modes::Picker;
-use crate::modes::RemovableDevices;
-use crate::modes::Selectable;
-use crate::modes::Shortcut;
-use crate::modes::Trash;
-use crate::modes::TuiApplications;
+use crate::io::{
+    drop_sudo_privileges, execute_and_capture_output_with_path, InputHistory, OpendalContainer,
+};
+use crate::modes::{
+    Bulk, CLApplications, CliApplications, Completion, Compresser, Content, ContentWindow,
+    ContextMenu, CryptoDeviceOpener, Display, Edit, Flagged, History, Input, InputCompleted,
+    IsoDevice, Marks, MountCommands, Navigate, PasswordHolder, Picker, RemovableDevices,
+    Selectable, Shortcut, Trash, TuiApplications,
+};
+use crate::{log_info, log_line};
 
 pub struct Menu {
     /// Window for scrollable menus

--- a/src/modes/edit/menu.rs
+++ b/src/modes/edit/menu.rs
@@ -150,7 +150,7 @@ impl Menu {
                 let files = match tab.display_mode {
                     Display::Preview => vec![],
                     Display::Tree => tab.search.complete(tab.tree.displayable().content()),
-                    Display::Flagged => tab.search.complete(self.flagged.content()),
+                    // Display::Flagged => tab.search.complete(self.flagged.content()),
                     Display::Directory => tab.search.complete(tab.directory.content()),
                 };
                 self.completion.search(files);
@@ -399,6 +399,7 @@ impl Menu {
             Navigate::TuiApplication => func(&mut self.tui_applications),
             Navigate::Cloud => func(&mut self.cloud),
             Navigate::Picker => func(&mut self.picker),
+            Navigate::Flagged => func(&mut self.flagged),
         }
     }
 
@@ -419,6 +420,7 @@ impl Menu {
             Navigate::TuiApplication => func(&self.tui_applications),
             Navigate::Cloud => func(&self.cloud),
             Navigate::Picker => func(&self.picker),
+            Navigate::Flagged => func(&self.flagged),
         }
     }
 }

--- a/src/modes/edit/menu.rs
+++ b/src/modes/edit/menu.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use crate::app::Tab;
 use crate::common::index_from_a;
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 use crate::common::CLI_PATH;
 use crate::common::INPUT_HISTORY_PATH;
 use crate::common::MARKS_FILEPATH;
@@ -191,7 +191,7 @@ impl Menu {
         let user_hostname_path_port: Vec<&str> = input.split(' ').collect();
         self.input.reset();
 
-        if !is_program_in_path(SSHFS_EXECUTABLE) {
+        if !is_in_path(SSHFS_EXECUTABLE) {
             log_info!("{SSHFS_EXECUTABLE} isn't in path");
             return;
         }

--- a/src/modes/edit/mod.rs
+++ b/src/modes/edit/mod.rs
@@ -39,7 +39,7 @@ pub use cli_menu::CliApplications;
 pub use cli_menu::Execute;
 pub use completion::{Completion, InputCompleted};
 pub use compress::Compresser;
-pub use context::ContextMenu;
+pub use context::{ContextMenu, MoreInfos};
 pub use copy_move::{copy_move, CopyMove};
 pub use cryptsetup::{lsblk_and_cryptsetup_installed, BlockDeviceAction, CryptoDeviceOpener};
 pub use decompress::{decompress_gz, decompress_xz, decompress_zip};

--- a/src/modes/edit/mount_help.rs
+++ b/src/modes/edit/mount_help.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
-use crate::{config::MENU_ATTRS, modes::PasswordHolder};
+use crate::config::MENU_ATTRS;
+use crate::modes::PasswordHolder;
 
 /// Bunch of methods used to mount / unmount a block device or a device image file.
 pub trait MountCommands {

--- a/src/modes/edit/node_creation.rs
+++ b/src/modes/edit/node_creation.rs
@@ -3,8 +3,7 @@ use std::fs;
 
 use anyhow::{Context, Result};
 
-use crate::app::Status;
-use crate::app::Tab;
+use crate::app::{Status, Tab};
 use crate::log_line;
 use crate::modes::Display as DisplayMode;
 

--- a/src/modes/edit/regex.rs
+++ b/src/modes/edit/regex.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use crate::{common::filename_from_path, modes::edit::Flagged};
+use crate::common::filename_from_path;
+use crate::modes::edit::Flagged;
 
 /// Flag every file matching a typed regex in current directory.
 ///

--- a/src/modes/edit/removable_devices.rs
+++ b/src/modes/edit/removable_devices.rs
@@ -3,18 +3,17 @@ use std::io::Read;
 
 use anyhow::{anyhow, Result};
 
-use crate::common::{current_uid, filename_from_path, is_dir_empty, is_in_path, MKDIR, MOUNT};
-use crate::common::{EJECT_EXECUTABLE, GIO};
+use crate::common::{
+    current_uid, filename_from_path, is_dir_empty, is_in_path, EJECT_EXECUTABLE, GIO, MKDIR, MOUNT,
+};
 use crate::impl_content;
 use crate::impl_selectable;
 use crate::io::{
     drop_sudo_privileges, execute_and_output, execute_sudo_command, reset_sudo_faillock,
     set_sudo_session,
 };
-use crate::log_info;
-use crate::log_line;
-use crate::modes::PasswordHolder;
-use crate::modes::{MountCommands, MountRepr};
+use crate::modes::{MountCommands, MountRepr, PasswordHolder};
+use crate::{log_info, log_line};
 
 /// Holds info about removable devices.
 /// We can navigate this struct.

--- a/src/modes/edit/removable_devices.rs
+++ b/src/modes/edit/removable_devices.rs
@@ -3,9 +3,7 @@ use std::io::Read;
 
 use anyhow::{anyhow, Result};
 
-use crate::common::{
-    current_uid, filename_from_path, is_dir_empty, is_program_in_path, MKDIR, MOUNT,
-};
+use crate::common::{current_uid, filename_from_path, is_dir_empty, is_in_path, MKDIR, MOUNT};
 use crate::common::{EJECT_EXECUTABLE, GIO};
 use crate::impl_content;
 use crate::impl_selectable;
@@ -47,7 +45,7 @@ impl RemovableDevices {
     }
 
     fn mtp_from_gio() -> Vec<Removable> {
-        if !is_program_in_path(GIO) {
+        if !is_in_path(GIO) {
             return vec![];
         }
         let Ok(output) = execute_and_output(GIO, [MOUNT, "-li"]) else {

--- a/src/modes/edit/search.rs
+++ b/src/modes/edit/search.rs
@@ -70,7 +70,6 @@ impl Search {
             Display::Directory => {
                 self.directory(status.current_tab_mut());
             }
-            Display::Flagged => self.flagged(&mut status.menu.flagged),
             _ => (),
         };
         status.update_second_pane_for_preview()
@@ -185,7 +184,7 @@ impl Search {
         found_path
     }
 
-    pub fn flagged(&mut self, flagged: &mut Flagged) {
+    fn flagged(&mut self, flagged: &mut Flagged) {
         if let Some(path) = self.select_next() {
             flagged.select_path(&path);
             return;

--- a/src/modes/edit/search.rs
+++ b/src/modes/edit/search.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::{
     app::{Status, Tab},
-    modes::{Display, Flagged, Go, To, ToPath, Tree},
+    modes::{Display, Go, To, ToPath, Tree},
 };
 
 #[derive(Clone)]
@@ -179,43 +179,6 @@ impl Search {
                     found_path = Some(line.path.to_path_buf());
                     found = true;
                 }
-            }
-        }
-        found_path
-    }
-
-    fn flagged(&mut self, flagged: &mut Flagged) {
-        if let Some(path) = self.select_next() {
-            flagged.select_path(&path);
-            return;
-        } else {
-            self.reset_paths();
-        }
-        if let Some(path) = self.find_in_flagged(flagged) {
-            flagged.select_path(&path);
-        }
-    }
-
-    fn find_in_flagged(&mut self, flagged: &Flagged) -> Option<std::path::PathBuf> {
-        let mut found = false;
-        let mut found_path = None;
-
-        for path in flagged
-            .content
-            .iter()
-            .skip(flagged.index + 1)
-            .chain(flagged.content.iter().take(flagged.index + 1))
-        {
-            if self
-                .regex
-                .is_match(&path.file_name().unwrap().to_string_lossy())
-            {
-                if !found {
-                    found = true;
-                    found_path = Some(path.to_path_buf());
-                    self.index = self.paths.len();
-                }
-                self.paths.push(path.to_path_buf());
             }
         }
         found_path

--- a/src/modes/edit/search.rs
+++ b/src/modes/edit/search.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
 
-use crate::{
-    app::{Status, Tab},
-    modes::{Display, Go, To, ToPath, Tree},
-};
+use crate::app::{Status, Tab};
+use crate::modes::{Display, Go, To, ToPath, Tree};
 
 #[derive(Clone)]
 pub struct Search {

--- a/src/modes/edit/second_line.rs
+++ b/src/modes/edit/second_line.rs
@@ -32,6 +32,7 @@ impl SecondLine for Navigate {
             Self::Cloud => "Remote navigation",
             Self::RemovableDevices => "",
             Self::Picker => "Pick an item",
+            Self::Flagged => "Pick a file",
         }
     }
 }

--- a/src/modes/edit/shell_parser.rs
+++ b/src/modes/edit/shell_parser.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
-use crate::{app::Status, common::path_to_string};
+use crate::app::Status;
+use crate::common::path_to_string;
 
 /// Expanded tokens from a configured command.
 /// %s is converted into a `Selected`

--- a/src/modes/edit/shortcut.rs
+++ b/src/modes/edit/shortcut.rs
@@ -2,12 +2,12 @@ use std::borrow::Borrow;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::common::HARDCODED_SHORTCUTS;
-use crate::common::{current_uid, path_to_config_folder, tilde, TRASH_FOLDER_FILES};
-use crate::impl_content;
-use crate::impl_selectable;
+use crate::common::{
+    current_uid, path_to_config_folder, tilde, HARDCODED_SHORTCUTS, TRASH_FOLDER_FILES,
+};
 use crate::io::git_root;
 use crate::log_info;
+use crate::{impl_content, impl_selectable};
 
 /// Holds the hardcoded and mountpoints shortcuts the user can jump to.
 /// Also know which shortcut is currently selected by the user.

--- a/src/modes/edit/sort.rs
+++ b/src/modes/edit/sort.rs
@@ -75,13 +75,13 @@ impl SortKind {
     /// If the character is lowercase, we sort by Ascending order, else Descending order.
     /// If the character is 'r' or 'R' we reverse current kind of sort.
     pub fn update_from_char(&mut self, c: char) {
-        match c {
-            'k' | 'K' => self.sort_by = SortBy::Kind,
-            'n' | 'N' => self.sort_by = SortBy::File,
-            'm' | 'M' => self.sort_by = SortBy::Date,
-            's' | 'S' => self.sort_by = SortBy::Size,
-            'e' | 'E' => self.sort_by = SortBy::Exte,
-            'r' | 'R' => self.order = self.order.reverse(),
+        match c.to_ascii_uppercase() {
+            'K' => self.sort_by = SortBy::Kind,
+            'N' => self.sort_by = SortBy::File,
+            'M' => self.sort_by = SortBy::Date,
+            'S' => self.sort_by = SortBy::Size,
+            'E' => self.sort_by = SortBy::Exte,
+            'R' => self.order = self.order.reverse(),
             _ => {
                 return;
             }

--- a/src/modes/edit/trash.rs
+++ b/src/modes/edit/trash.rs
@@ -6,13 +6,12 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context, Result};
 use chrono::{Local, NaiveDateTime};
 
-use crate::common::{read_lines, tilde, TRASH_CONFIRM_LINE};
-use crate::common::{TRASH_FOLDER_FILES, TRASH_FOLDER_INFO, TRASH_INFO_EXTENSION};
+use crate::common::{
+    read_lines, tilde, TRASH_CONFIRM_LINE, TRASH_FOLDER_FILES, TRASH_FOLDER_INFO,
+    TRASH_INFO_EXTENSION,
+};
 use crate::config::Bindings;
-use crate::impl_content;
-use crate::impl_selectable;
-use crate::log_info;
-use crate::log_line;
+use crate::{impl_content, impl_selectable, log_info, log_line};
 
 const TRASHINFO_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
 

--- a/src/modes/edit/tui_menu.rs
+++ b/src/modes/edit/tui_menu.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde_yml::Mapping;
 
 use crate::app::Status;
-use crate::common::is_program_in_path;
+use crate::common::is_in_path;
 use crate::impl_content;
 use crate::impl_selectable;
 use crate::io::{execute_without_output, execute_without_output_with_path};
@@ -33,7 +33,7 @@ fn execute_shell(status: &Status) -> Result<()> {
 
 /// Directly open a a TUI application
 pub fn open_tui_program(status: &mut Status, program: &str) -> Result<()> {
-    if is_program_in_path(program) {
+    if is_in_path(program) {
         require_cwd_and_command(status, program)
     } else {
         Ok(())
@@ -72,7 +72,7 @@ impl CLApplications<String, ()> for TuiApplications {
             let Some(command) = key.as_str() else {
                 continue;
             };
-            if is_program_in_path(command) {
+            if is_in_path(command) {
                 self.content.push(command.to_owned());
             }
         }

--- a/src/modes/edit/tui_menu.rs
+++ b/src/modes/edit/tui_menu.rs
@@ -3,12 +3,10 @@ use serde_yml::Mapping;
 
 use crate::app::Status;
 use crate::common::is_in_path;
-use crate::impl_content;
-use crate::impl_selectable;
 use crate::io::{execute_without_output, execute_without_output_with_path};
 use crate::log_line;
-use crate::modes::CLApplications;
-use crate::modes::Execute;
+use crate::modes::{CLApplications, Execute};
+use crate::{impl_content, impl_selectable};
 
 /// Execute a command requiring to be ran from current working directory.
 ///

--- a/src/modes/mode.rs
+++ b/src/modes/mode.rs
@@ -331,6 +331,7 @@ impl Edit {
             Self::Navigate(Navigate::Marks(MarkAction::Jump)) => "Type the mark letter to jump there. up, down to navigate, ENTER to select an element",
             Self::Navigate(Navigate::Marks(MarkAction::New)) => "Type the mark set a mark here. up, down to navigate, ENTER to select an element",
             Self::Navigate(Navigate::Cloud) => "l: leave drive, arrows: navigation, Enter: enter dir / download file, d: new dir, x: delete selected, u: upload local file",
+            Self::Navigate(Navigate::Flagged) => "Up, Down: navigate, Enter / j: jump to this file, x: remove from flagged, u: clear",
             Self::Navigate(_) => "up, down to navigate, Enter to select an element",
             Self::NeedConfirmation(_) => "",
             _ => "",

--- a/src/modes/mode.rs
+++ b/src/modes/mode.rs
@@ -227,6 +227,8 @@ pub enum Navigate {
     Cloud,
     /// Picker menu
     Picker,
+    /// Flagged files
+    Flagged,
 }
 
 impl fmt::Display for Navigate {
@@ -250,6 +252,7 @@ impl fmt::Display for Navigate {
             Self::Context => write!(f, "Context"),
             Self::Cloud => write!(f, "Cloud"),
             Self::Picker => write!(f, "Picker"),
+            Self::Flagged => write!(f, "Flagged"),
         }
     }
 }
@@ -376,6 +379,4 @@ pub enum Display {
     Tree,
     /// Preview a file or directory
     Preview,
-    /// Fuzzy
-    Flagged,
 }


### PR DESCRIPTION
- Fixed the documentation and updated the badges
- Flagged files are now displayed in a menu instead of the main window. You can still jump to them, removed them individually
- Fix jump mode (Alt+g) to allow paths to file. It will jump there and select the file.
- Preview valid symlink as their target. Broken symlink aren't previewed at all
- Fixed a few bugs. See details below.
- **Breaking changes**: color configuration.

  Only one mapping is used in config.yml. All colors are now regrouped there.
  Some names have changed :

  - "start" -> "normal_start"
  - "stop" -> "normal_stop"

  Your old config will still be loaded, but their colors won't be recognized unless you update the config.
  See the [source](config_file/fm/config.yml) for more infos.
